### PR TITLE
Fix clicking and getting of screen shot

### DIFF
--- a/main.py
+++ b/main.py
@@ -66,7 +66,7 @@ def state_tool(use_vision:bool=False):
     scrollable_elements=desktop_state.tree_state.scrollable_elements_to_string()
     apps=desktop_state.apps_to_string()
     active_app=desktop_state.active_app_to_string()
-    return dedent(f'''
+    return [dedent(f'''
     Default Language of User:
     {default_language} with encoding: {desktop.encoding}
                             
@@ -84,7 +84,7 @@ def state_tool(use_vision:bool=False):
 
     List of Scrollable Elements:
     {scrollable_elements or 'No scrollable elements found.'}
-    ''')
+    ''')]+([Image(data=desktop_state.screenshot,format='png')] if use_vision else [])
     
 @mcp.tool(name='Clipboard-Tool',description='Copy text to clipboard or retrieve current clipboard content. Use "copy" mode with text parameter to copy, "paste" mode to retrieve.')
 def clipboard_tool(mode: Literal['copy', 'paste'], text: str = None)->str:

--- a/src/desktop/service.py
+++ b/src/desktop/service.py
@@ -220,9 +220,7 @@ class Desktop:
     def screenshot_in_bytes(self,screenshot:PILImage)->bytes:
         buffer=BytesIO()
         screenshot.save(buffer,format='PNG')
-        img_base64 = base64.b64encode(buffer.getvalue()).decode('utf-8')
-        data_uri = f"data:image/png;base64,{img_base64}"
-        return data_uri
+        return buffer.getvalue()
 
     def get_screenshot(self,scale:float=0.7)->Image.Image:
         screenshot=pyautogui.screenshot()


### PR DESCRIPTION
 - Click method already sends mouse down and up event, so there is no need to send them one more time. This bugs some controls that show popup on click and then on second click they hide the popup.

 - Return code that generates the screenshot.