### PR TITLE
fix(desktop): initialize desktop_state in is_app_running to avoid AttributeError

### DIFF
--- a/src/desktop/service.py
+++ b/src/desktop/service.py
@@ -130,10 +130,12 @@ class Desktop:
             app_control.MoveWindow(x,y,width,height)
             return (f'{active_app.name} resized to {width}x{height} at {x},{y}.',0)
     
-    def is_app_running(self,name:str)->bool:
-        apps={app.name:app for app in [self.desktop_state.active_app]+self.desktop_state.apps if app is not None}
-        return process.extractOne(name,list(apps.keys()),score_cutoff=60) is not None
-        
+    def is_app_running(self, name: str) -> bool:
+        if self.desktop_state is None:
+            self.get_state()
+        apps = {app.name: app for app in [self.desktop_state.active_app] + self.desktop_state.apps if app is not None}
+        return process.extractOne(name, list(apps.keys()), score_cutoff=60) is not None
+
     def launch_app(self,name:str)->tuple[str,int]:
         apps_map=self.get_apps_from_start_menu()
         matched_app=process.extractOne(name,apps_map.keys(),score_cutoff=70)


### PR DESCRIPTION
- Problem: When `Launch-Tool` polls `is_app_running` immediately after starting an app, `Desktop.desktop_state` may still be `None`. This leads to:
  - `'NoneType' object has no attribute 'active_app'` in `src/desktop/service.py:134`.
- Root cause: `desktop_state` is only set in `get_state()`, but `is_app_running` accessed it unconditionally.
- Fix: In `is_app_running`, if `self.desktop_state is None`, call `self.get_state()` before using it.
- Impact: Prevents crashes on first-run checks; makes runtime more resilient without changing external behavior.

Repro (before):
- Start server via SSE, run `Launch-Tool` for any app.
- Observe AttributeError trace pointing to `is_app_running`.

Verification (after):
- Launch an app with `Launch-Tool`; no exception thrown.
- `State-Tool` and other tools continue to function as before.

Notes:
- A follow-up could add a similar guard in `switch_app` and/or pre-call `get_state()` in `launch_tool` for extra safety.