### PR TITLE
fix: inherit environment variables in PowerShell subprocess

### DIFF
--- a/src/windows_mcp/desktop/service.py
+++ b/src/windows_mcp/desktop/service.py
@@ -147,7 +147,8 @@ class Desktop:
                 ['powershell', '-NoProfile', '-EncodedCommand', encoded], 
                 capture_output=True,  # No errors='ignore' - let subprocess return bytes
                 timeout=timeout,
-                cwd=os.path.expanduser(path='~')
+                cwd=os.path.expanduser(path='~'),
+                env=os.environ.copy()  # Inherit environment variables including PATH
             )
             # Handle both bytes and str output (subprocess behavior varies by environment)
             stdout = result.stdout


### PR DESCRIPTION
## Summary
Fix PowerShell subprocess not inheriting environment variables, causing commands like `node --version` and `git --version` to fail with "not recognized" errors.

## Problem
When using the Shell tool, commands fail even when tools are in the system PATH because `subprocess.run()` doesn't inherit the parent process's environment.

## Solution
Add `env=os.environ.copy()` to the `subprocess.run()` call in `execute_command()`.

## Testing
- Before: `node --version` → "not recognized" error
- After: `node --version` → `v25.5.0` ✓

Fixes #70