### PR TITLE
feat: expose use_annotation parameter in Snapshot tool

### DIFF
--- a/src/windows_mcp/__main__.py
+++ b/src/windows_mcp/__main__.py
@@ -178,7 +178,7 @@ def file_system_tool(
 
 @mcp.tool(
     name='Snapshot',
-    description="Captures complete desktop state including: system language, focused/opened windows, interactive elements (buttons, text fields, links, menus with coordinates), and scrollable areas. Set use_vision=True to include screenshot with cursor highlight. Set width_reference_lines/height_reference_lines to overlay a grid for better spatial reasoning (make sure vision is enabled to use it). Set use_dom=True for browser content to get web page elements instead of browser UI. Set display=[0] or display=[0,1] to limit all returned Snapshot information to specific screens; omit it to keep the default full-desktop behavior. Always call this first to understand the current desktop state before taking actions.",
+    description="Captures complete desktop state including: system language, focused/opened windows, interactive elements (buttons, text fields, links, menus with coordinates), and scrollable areas. Set use_vision=True to include screenshot with cursor highlight. Set use_annotation=False to get a clean screenshot without bounding box overlays on UI elements (default: True, draws colored rectangles around detected elements). Set width_reference_lines/height_reference_lines to overlay a grid for better spatial reasoning (make sure vision is enabled to use it). Set use_dom=True for browser content to get web page elements instead of browser UI. Set display=[0] or display=[0,1] to limit all returned Snapshot information to specific screens; omit it to keep the default full-desktop behavior. Always call this first to understand the current desktop state before taking actions.",
     annotations=ToolAnnotations(
         title="Snapshot",
         readOnlyHint=True,
@@ -191,6 +191,7 @@ def file_system_tool(
 def state_tool(
     use_vision: bool | str = False,
     use_dom: bool | str = False,
+    use_annotation: bool | str = True,
     width_reference_line: int | None = None,
     height_reference_line: int | None = None,
     display: list[int] | None = None,
@@ -199,6 +200,7 @@ def state_tool(
     try:
         use_vision = use_vision is True or (isinstance(use_vision, str) and use_vision.lower() == 'true')
         use_dom = use_dom is True or (isinstance(use_dom, str) and use_dom.lower() == 'true')
+        use_annotation = use_annotation is True or (isinstance(use_annotation, str) and use_annotation.lower() == 'true')
         display_indices = Desktop.parse_display_selection(display)
         
         grid_lines = None
@@ -208,6 +210,7 @@ def state_tool(
         desktop_state = desktop.get_state(
             use_vision=use_vision,
             use_dom=use_dom,
+            use_annotation=use_annotation,
             as_bytes=False,
             grid_lines=grid_lines,
             display_indices=display_indices,


### PR DESCRIPTION
## Summary

Expose the existing `use_annotation` parameter from `Desktop.get_state()` through the MCP `Snapshot` tool, allowing clients to control whether bounding box annotations are drawn on screenshots.

## Problem

When `use_vision=True`, the `Snapshot` tool always returns screenshots with colored bounding boxes drawn around detected UI elements (via `get_annotated_screenshot()`). The `Desktop.get_state()` method already supports a `use_annotation` parameter to control this behavior, but it was not exposed through the MCP tool interface.

This is particularly problematic for AI agents using Computer Use (e.g., Claude, GPT-4V), where the colored rectangles can:
- Obscure text that the agent needs to read
- Cover buttons and interactive elements
- Interfere with the agent's ability to accurately identify UI components
- Degrade overall vision-based automation performance

## Solution

Add `use_annotation: bool | str = True` as an optional parameter to the `Snapshot` tool (`state_tool`), and pass it through to `desktop.get_state()`.

### Changes (4 lines added, 1 modified):

1. **Tool description**: Added documentation for the new parameter
2. **Function signature**: Added `use_annotation: bool | str = True` parameter
3. **Boolean parsing**: Added standard bool/str parsing (consistent with `use_vision` and `use_dom`)
4. **get_state() call**: Pass `use_annotation` through to `desktop.get_state()`

### Behavior:
- `use_annotation=True` (default): Draws colored bounding boxes around UI elements — **no change from current behavior**
- `use_annotation=False`: Returns a clean screenshot without overlays

## Backward Compatibility

Default value is `True`, preserving existing behavior. No breaking changes for current users.

## Testing

Tested with a real-world AI automation system running Claude Computer Use across multiple Windows machines. Setting `use_annotation=False` significantly improved the agent's ability to read UI elements and interact with the desktop accurately.