### PR TITLE
Switch to minimized window in a single call via unified `bring_window_to_top` logic

### DIFF
--- a/src/windows_mcp/desktop/service.py
+++ b/src/windows_mcp/desktop/service.py
@@ -444,11 +444,11 @@ class Desktop:
             window = windows.get(window_name)
             target_handle = window.handle
 
-            if uia.IsIconic(target_handle):
-                uia.ShowWindow(target_handle, win32con.SW_RESTORE)
-                content = f"{window_name.title()} restored from Minimized state."
+            was_minimized = uia.IsIconic(target_handle)
+            self.bring_window_to_top(target_handle)
+            if was_minimized:
+                content = f"Restored {window_name.title()} from minimized and switched to it."
             else:
-                self.bring_window_to_top(target_handle)
                 content = f"Switched to {window_name.title()} window."
             return content, 0
         except Exception as e:


### PR DESCRIPTION
## Problem

When using the `App` tool in `switch` mode to focus a minimized window (e.g., Zoom Workplace), the previous logic only restored the window from its minimized state — it did **not** bring it to the foreground. A second call to the same tool was required to actually switch focus to the window.

https://github.com/user-attachments/assets/f8895f50-0e57-4e43-807d-851de2aa9087

This happened because [the original code](https://github.com/CursorTouch/Windows-MCP/blob/7738674c4925f10148b952ba19f038b256912101/src/windows_mcp/desktop/service.py#L447) branched on `IsIconic`:
- If minimized → call `ShowWindow(SW_RESTORE)` only (no focus change)
- If not minimized → call `bring_window_to_top` (which both restores and focuses)

## Fix

Consolidated the two branches into a single unified call to `bring_window_to_top`, which already handles the minimized case internally by calling `ShowWindow(SW_RESTORE)` before setting the window as foreground. The `was_minimized` flag is retained solely for generating a descriptive return message.


```python
# After — single path, always brings window to foreground regardless of state
was_minimized = uia.IsIconic(target_handle)
self.bring_window_to_top(target_handle)
if was_minimized:
    content = f"Restored {window_name.title()} from minimized and switched to it."
else:
    content = f"Switched to {window_name.title()} window."
```

`bring_window_to_top` already contains the restore-then-focus sequence:

```python
def bring_window_to_top(self, target_handle: int):
    if win32gui.IsIconic(target_handle):
        win32gui.ShowWindow(target_handle, win32con.SW_RESTORE)
    # ... thread attachment and SetForegroundWindow logic
```

## Result

Switching to a minimized window now works correctly in a single tool call — the window is both restored from minimized state and brought to the foreground atomically.

---

Thanks for building such a useful MCP server! Hope this small fix improves the experience.
