### PR TITLE
Extend resize mode to support targeting window by name

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -66,7 +66,7 @@
   "tools": [
     {
       "name": "App",
-      "description": "Manages Windows applications with three modes: 'launch' (opens the prescibed application), 'resize' (adjusts active window size/position), 'switch' (brings specific window into focus)."
+      "description": "Manages Windows applications with three modes: 'launch' (opens the prescibed application), 'resize' (adjusts the size/position of a named window or the active window if name is omitted), 'switch' (brings specific window into focus)."
     },
     {
       "name": "Shell",

--- a/src/windows_mcp/__main__.py
+++ b/src/windows_mcp/__main__.py
@@ -73,7 +73,7 @@ mcp = FastMCP(name="windows-mcp", instructions=instructions, lifespan=lifespan)
 
 @mcp.tool(
     name="App",
-    description="Manages Windows applications with three modes: 'launch' (opens the prescibed application), 'resize' (adjusts active window size/position), 'switch' (brings specific window into focus).",
+    description="Manages Windows applications with three modes: 'launch' (opens the prescibed application), 'resize' (adjusts the size/position of a named window or the active window if name is omitted), 'switch' (brings specific window into focus).",
     annotations=ToolAnnotations(
         title="App",
         readOnlyHint=False,

--- a/src/windows_mcp/desktop/service.py
+++ b/src/windows_mcp/desktop/service.py
@@ -315,18 +315,54 @@ class Desktop:
         reader = csv.DictReader(io.StringIO(response))
         return "".join([row.get("DisplayName") for row in reader])
 
+    def _find_window_by_name(self, name: str, refresh_state: bool = False) -> tuple["Window | None", str]:
+        """Find a window by fuzzy name match. Returns (window, error_msg).
+        If the returned window is None, error_msg describes the failure reason.
+
+        If refresh_state is True, always refresh desktop_state before searching;
+        otherwise refresh only when desktop_state is absent or empty.
+        """
+        if refresh_state or self.desktop_state is None or not self.desktop_state.windows:
+            self.get_state()
+        if self.desktop_state is None:
+            return None, "Failed to get desktop state. Please try again."
+
+        window_list = [
+            w
+            for w in [self.desktop_state.active_window] + (self.desktop_state.windows or [])
+            if w is not None
+        ]
+        if not window_list:
+            return None, "No windows found on the desktop."
+
+        windows = {window.name: window for window in window_list}
+        matched_window = process.extractOne(name, list(windows.keys()), score_cutoff=70)
+        if matched_window is None:
+            return None, f"Application {name.title()} not found."
+        window_name, _ = matched_window
+        return windows.get(window_name), ""
+
     def resize_app(
-        self, size: tuple[int, int] = None, loc: tuple[int, int] = None
+        self, name: str | None = None, size: tuple[int, int] = None, loc: tuple[int, int] = None
     ) -> tuple[str, int]:
-        active_window = self.desktop_state.active_window
-        if active_window is None:
-            return "No active window found", 1
-        if active_window.status == Status.MINIMIZED:
-            return f"{active_window.name} is minimized", 1
-        elif active_window.status == Status.MAXIMIZED:
-            return f"{active_window.name} is maximized", 1
+        if name is not None:
+            target_window, error = self._find_window_by_name(name, refresh_state=True)
+            if target_window is None:
+                return error, 1
         else:
-            window_control = uia.ControlFromHandle(active_window.handle)
+            # If no name provided, try to resize the active window
+            target_window = self.desktop_state.active_window if self.desktop_state else None
+
+            if target_window is None:
+                return "No active window found", 1
+
+        # target_window is guaranteed to be non-None here
+        if target_window.status == Status.MINIMIZED:
+            return f"{target_window.name} is minimized", 1
+        elif target_window.status == Status.MAXIMIZED:
+            return f"{target_window.name} is maximized", 1
+        else:
+            window_control = uia.ControlFromHandle(target_window.handle)
             if loc is None:
                 x = window_control.BoundingRectangle.left
                 y = window_control.BoundingRectangle.top
@@ -338,7 +374,7 @@ class Desktop:
             x, y = loc
             width, height = size
             window_control.MoveWindow(x, y, width, height)
-            return (f"{active_window.name} resized to {width}x{height} at {x},{y}.", 0)
+            return (f"{target_window.name} resized to {width}x{height} at {x},{y}.", 0)
 
     def is_app_running(self, name: str) -> bool:
         windows, _ = self.get_windows()
@@ -376,7 +412,7 @@ class Desktop:
                     return f"{name.title()} launched."
                 return f"Launching {name.title()} sent, but window not detected yet."
             case "resize":
-                response, status = self.resize_app(size=size, loc=loc)
+                response, status = self.resize_app(name=name, size=size, loc=loc)
                 if status != 0:
                     return response
                 else:
@@ -420,36 +456,18 @@ class Desktop:
 
     def switch_app(self, name: str):
         try:
-            # Refresh state if desktop_state is None or has no windows
-            if self.desktop_state is None or not self.desktop_state.windows:
-                self.get_state()
-            if self.desktop_state is None:
-                return ("Failed to get desktop state. Please try again.", 1)
+            window, error = self._find_window_by_name(name)
+            if window is None:
+                return error, 1
 
-            window_list = [
-                w
-                for w in [self.desktop_state.active_window] + self.desktop_state.windows
-                if w is not None
-            ]
-            if not window_list:
-                return ("No windows found on the desktop.", 1)
-
-            windows = {window.name: window for window in window_list}
-            matched_window: tuple[str, float] | None = process.extractOne(
-                name, list(windows.keys()), score_cutoff=70
-            )
-            if matched_window is None:
-                return (f"Application {name.title()} not found.", 1)
-            window_name, _ = matched_window
-            window = windows.get(window_name)
             target_handle = window.handle
 
             was_minimized = uia.IsIconic(target_handle)
             self.bring_window_to_top(target_handle)
             if was_minimized:
-                content = f"Restored {window_name.title()} from minimized and switched to it."
+                content = f"Restored {window.name.title()} from minimized and switched to it."
             else:
-                content = f"Switched to {window_name.title()} window."
+                content = f"Switched to {window.name.title()} window."
             return content, 0
         except Exception as e:
             return (f"Error switching app: {str(e)}", 1)


### PR DESCRIPTION
## Problem

Currently the `resize` mode of the `App` tool only operates on the **active window** and the `name` parameter is ignored.

This leads to a subtle bug in practice. When an AI agent (e.g., Claude) is asked to resize a non-active window, it usually first calls `switch` to bring the target window to the foreground, then calls `resize`. However, the resize still operates on the window that was active **at snapshot time** — before the switch happened. So the agent complains that it is always resizing the wrong window and tries rolling back to the pwsh command.

https://github.com/user-attachments/assets/47f3d64f-2c1c-4899-9210-c21dd231a9ca

> Note: The stale snapshot issue may warrant a separate fix, but supporting `name` in resize mode can sidestep the problem.

## Solution

- **Add `name` parameter support to `resize_app`**: When `name` is provided, the tool fuzzy-matches and targets the specified window directly; when omitted, it falls back to the active window, preserving full backward compatibility.
- **Extract shared window lookup logic into `_find_window_by_name` helper**: Both `switch_app` and `resize_app` need to locate a window by fuzzy name match. This duplicated logic is refactored into a single reusable method.
- **Update tool descriptions** in `__main__.py` and `manifest.json` so the agent understands `name` is effective in resize mode and uses it correctly.

With these changes, when Claude is asked to resize a non-active window, it will pass the window name directly to the `resize` call rather than issuing `switch` first, resulting in correct and reliable behavior.

## Changes

- `src/windows_mcp/desktop/service.py`
  - New `_find_window_by_name(name, refresh_state)` method encapsulating window list retrieval and fuzzy matching
  - `resize_app` now accepts an optional `name` parameter and delegates to `_find_window_by_name` when provided
  - `switch_app` refactored to use `_find_window_by_name`, removing duplicated code
- `src/windows_mcp/__main__.py` — Updated `App` tool description to reflect that `name` works in resize mode
- `manifest.json` — Updated tool description to match

## The demo after modification

https://github.com/user-attachments/assets/8d23282c-4cac-43a9-a2aa-216b82c04555


