### PR TITLE
feat: add fast screenshot-only path for Snapshot

### DIFF
--- a/src/windows_mcp/__main__.py
+++ b/src/windows_mcp/__main__.py
@@ -178,7 +178,7 @@ def file_system_tool(
 
 @mcp.tool(
     name='Snapshot',
-    description="Captures complete desktop state including: system language, focused/opened windows, interactive elements (buttons, text fields, links, menus with coordinates), and scrollable areas. Set use_vision=True to include screenshot with cursor highlight. Set use_annotation=False to get a clean screenshot without bounding box overlays on UI elements (default: True, draws colored rectangles around detected elements). Set width_reference_lines/height_reference_lines to overlay a grid for better spatial reasoning (make sure vision is enabled to use it). Set use_dom=True for browser content to get web page elements instead of browser UI. Set display=[0] or display=[0,1] to limit all returned Snapshot information to specific screens; omit it to keep the default full-desktop behavior. Always call this first to understand the current desktop state before taking actions.",
+    description="Captures complete desktop state including: system language, focused/opened windows, interactive elements (buttons, text fields, links, menus with coordinates), and scrollable areas. Set use_vision=True to include screenshot with cursor highlight. Set use_annotation=False to get a clean screenshot without bounding box overlays on UI elements (default: True, draws colored rectangles around detected elements). Set use_ui_tree=False for a faster screenshot-only snapshot when you do not need interactive or scrollable element extraction. Set width_reference_lines/height_reference_lines to overlay a grid for better spatial reasoning (make sure vision is enabled to use it). Set use_dom=True for browser content to get web page elements instead of browser UI. Set display=[0] or display=[0,1] to limit all returned Snapshot information to specific screens; omit it to keep the default full-desktop behavior. Always call this first to understand the current desktop state before taking actions.",
     annotations=ToolAnnotations(
         title="Snapshot",
         readOnlyHint=True,
@@ -192,6 +192,7 @@ def state_tool(
     use_vision: bool | str = False,
     use_dom: bool | str = False,
     use_annotation: bool | str = True,
+    use_ui_tree: bool | str = True,
     width_reference_line: int | None = None,
     height_reference_line: int | None = None,
     display: list[int] | None = None,
@@ -201,6 +202,11 @@ def state_tool(
         use_vision = use_vision is True or (isinstance(use_vision, str) and use_vision.lower() == 'true')
         use_dom = use_dom is True or (isinstance(use_dom, str) and use_dom.lower() == 'true')
         use_annotation = use_annotation is True or (isinstance(use_annotation, str) and use_annotation.lower() == 'true')
+        use_ui_tree = use_ui_tree is True or (isinstance(use_ui_tree, str) and use_ui_tree.lower() == 'true')
+
+        if use_dom and not use_ui_tree:
+            raise ValueError("use_dom=True requires use_ui_tree=True")
+
         display_indices = Desktop.parse_display_selection(display)
         
         grid_lines = None
@@ -211,6 +217,7 @@ def state_tool(
             use_vision=use_vision,
             use_dom=use_dom,
             use_annotation=use_annotation,
+            use_ui_tree=use_ui_tree,
             as_bytes=False,
             grid_lines=grid_lines,
             display_indices=display_indices,

--- a/src/windows_mcp/desktop/service.py
+++ b/src/windows_mcp/desktop/service.py
@@ -5,7 +5,7 @@ from windows_mcp.vdm.core import (
     is_window_on_current_desktop,
 )
 from windows_mcp.desktop.views import DesktopState, Window, Browser, Status, Size
-from windows_mcp.tree.views import BoundingBox, TreeElementNode
+from windows_mcp.tree.views import BoundingBox, TreeElementNode, TreeState
 from concurrent.futures import ThreadPoolExecutor
 from PIL import ImageGrab, ImageFont, ImageDraw, Image
 from windows_mcp.tree.service import Tree
@@ -77,6 +77,7 @@ class Desktop:
         use_annotation: bool | str = True,
         use_vision: bool | str = False,
         use_dom: bool | str = False,
+        use_ui_tree: bool | str = True,
         as_bytes: bool | str = False,
         scale: float = 1.0,
         grid_lines: tuple[int, int] | None = None,
@@ -90,10 +91,17 @@ class Desktop:
             isinstance(use_vision, str) and use_vision.lower() == "true"
         )
         use_dom = use_dom is True or (isinstance(use_dom, str) and use_dom.lower() == "true")
+        use_ui_tree = use_ui_tree is True or (
+            isinstance(use_ui_tree, str) and use_ui_tree.lower() == "true"
+        )
         as_bytes = as_bytes is True or (isinstance(as_bytes, str) and as_bytes.lower() == "true")
+
+        if use_dom and not use_ui_tree:
+            raise ValueError("use_dom=True requires use_ui_tree=True")
 
         start_time = time()
         capture_rect = self.get_display_union_rect(display_indices) if display_indices else None
+        screenshot_region = self._rect_to_bounding_box(capture_rect) if capture_rect else None
 
         controls_handles = self.get_controls_handles()  # Taskbar,Program Manager,Apps, Dialogs
         windows, windows_handles = self.get_windows(controls_handles=controls_handles)  # Apps
@@ -118,18 +126,30 @@ class Desktop:
         logger.debug(f"Active window: {active_window or 'No Active Window Found'}")
         logger.debug(f"Windows: {windows}")
 
-        # Preparing handles for Tree
-        other_windows_handles = list(controls_handles - windows_handles)
+        if use_ui_tree:
+            other_windows_handles = list(controls_handles - windows_handles)
+            tree_state = self.tree.get_state(
+                active_window_handle, other_windows_handles, use_dom=use_dom
+            )
+        else:
+            root_box = screenshot_region or self.tree.screen_box
+            tree_state = TreeState(
+                status=True,
+                root_node=TreeElementNode(
+                    name="Desktop",
+                    control_type="PaneControl",
+                    bounding_box=root_box,
+                    center=root_box.get_center(),
+                    window_name="Desktop",
+                    metadata={},
+                ),
+            )
 
-        tree_state = self.tree.get_state(
-            active_window_handle, other_windows_handles, use_dom=use_dom
-        )
-
-        screenshot_region = self._rect_to_bounding_box(capture_rect) if capture_rect else None
         if screenshot_region:
             active_window = self._filter_window_to_region(active_window, screenshot_region)
             windows = self._filter_windows_to_region(windows, screenshot_region)
-            tree_state = self._filter_tree_state_to_region(tree_state, screenshot_region)
+            if use_ui_tree:
+                tree_state = self._filter_tree_state_to_region(tree_state, screenshot_region)
             if cursor_position and not self._point_in_region(cursor_position, screenshot_region):
                 cursor_position = None
 

--- a/tests/test_snapshot_display_filter.py
+++ b/tests/test_snapshot_display_filter.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from PIL import Image
@@ -166,3 +166,41 @@ class TestDisplayFiltering:
         assert state.screenshot_size.to_string() == "(1920,1080)"
         assert state.screenshot_region.xyxy_to_string() == "(1920,0,3840,1080)"
         assert state.screenshot_displays == [1]
+
+    def test_get_state_skips_tree_capture_when_use_ui_tree_false(self, desktop):
+        desktop.tree = MagicMock()
+        desktop.tree.screen_box = make_box(0, 0, 1920, 1080)
+        desktop.get_controls_handles = MagicMock(return_value={1})
+        active_window = Window(
+            name="Browser",
+            is_browser=True,
+            depth=0,
+            status=Status.NORMAL,
+            bounding_box=make_box(100, 100, 700, 500),
+            handle=1,
+            process_id=11,
+        )
+        desktop.get_windows = MagicMock(return_value=([active_window], {1}))
+        desktop.get_active_window = MagicMock(return_value=active_window)
+        desktop.get_cursor_location = MagicMock(return_value=(250, 180))
+        desktop.get_screenshot = MagicMock(return_value=Image.new("RGB", (800, 600), "white"))
+
+        with patch("windows_mcp.desktop.service.get_current_desktop", return_value={"name": "Desktop 1"}):
+            with patch("windows_mcp.desktop.service.get_all_desktops", return_value=[{"name": "Desktop 1"}]):
+                state = desktop.get_state(
+                    use_vision=True,
+                    use_annotation=False,
+                    use_ui_tree=False,
+                )
+
+        desktop.tree.get_state.assert_not_called()
+        assert state.tree_state.root_node.bounding_box == desktop.tree.screen_box
+        assert state.tree_state.interactive_nodes == []
+        assert state.tree_state.scrollable_nodes == []
+        assert state.screenshot_size.to_string() == "(800,600)"
+
+    def test_get_state_rejects_dom_without_ui_tree(self, desktop):
+        desktop.tree = MagicMock()
+
+        with pytest.raises(ValueError, match="use_dom=True requires use_ui_tree=True"):
+            desktop.get_state(use_dom=True, use_ui_tree=False)


### PR DESCRIPTION
## Summary

This PR adds a `use_ui_tree` parameter to the `Snapshot` tool so clients can request a fast screenshot-only path when they do not need interactive or scrollable element extraction.

## Why this is needed

In PR #95, I exposed the existing `use_annotation` parameter so callers could disable bounding box overlays.
That fixed the visual-obstruction problem, but it did **not** fully solve the performance problem.

The remaining issue is that `Snapshot` still performs the full UI tree capture unconditionally inside `Desktop.get_state()`, even when callers use:

- `use_vision=True`
- `use_annotation=False`

In practice, this means callers can get a clean screenshot, but they still pay the full cost of accessibility tree traversal, window-by-window retries, and related UIA work before the image is returned.
That makes screenshot capture unnecessarily slow for vision-only agent workflows.

## Root cause

`Desktop.get_state()` always calls:

```python
other_windows_handles = list(controls_handles - windows_handles)
tree_state = self.tree.get_state(
    active_window_handle, other_windows_handles, use_dom=use_dom
)
```

That happens before screenshot generation and is independent of `use_annotation`.
So `use_annotation=False` only disables rectangle drawing, not the expensive tree capture that dominates latency.

## What this PR changes

- Adds `use_ui_tree: bool | str = True` to the `Snapshot` tool
- Threads `use_ui_tree` through to `Desktop.get_state()`
- Skips `self.tree.get_state(...)` entirely when `use_ui_tree=False`
- Returns an empty `TreeState` shell in that mode so the response format remains stable
- Rejects `use_dom=True` together with `use_ui_tree=False`, because DOM extraction depends on the UI tree path
- Updates Snapshot tool description to document the new fast screenshot-only mode

## Behavior

### Default behavior

No breaking changes.

- `use_ui_tree=True` remains the default
- Existing clients keep the current Snapshot behavior

### Fast screenshot-only behavior

Clients that only need the image can now call:

```json
{
  "use_vision": true,
  "use_annotation": false,
  "use_ui_tree": false
}
```

This avoids the expensive UI tree traversal and returns a clean screenshot faster.

## Testing

Added regression coverage for:

- skipping tree capture when `use_ui_tree=False`
- rejecting `use_dom=True` with `use_ui_tree=False`

Focused test run:

```bash
python -m pytest -q tests/test_snapshot_display_filter.py
```

Result:

- 11 passed

## Notes

PR #95 was necessary, but incomplete for the end-to-end screenshot performance issue.
It exposed overlay control, while this PR addresses the remaining root cause by making UI tree capture optional for screenshot-only workflows.