### PR TITLE
fix: keyboard focus not transferred when switching foreground window

### DIFF
--- a/src/windows_mcp/desktop/service.py
+++ b/src/windows_mcp/desktop/service.py
@@ -530,8 +530,22 @@ class Desktop:
                 win32gui.BringWindowToTop(target_handle)
                 return
 
+            # We attach our own thread (current_tid) to both the foreground and
+            # target window threads to make focus change succeed.
+            #
+            # Simply attaching foreground_thread to target_thread is not sufficient:
+            # SetForegroundWindow is called from our MCP thread, and Windows requires
+            # the calling process to satisfy the "received the last input event"
+            # criterion. Without attaching current_tid, the system may only bring the
+            # target window to the front but refuse to transfer keyboard
+            # focus, causing subsequent keyboard input to remain in the previous window.
+            #
+            # By attaching current_tid to both threads, our thread shares
+            # their input state and inherits that eligibility, allowing the system to
+            # grant the focus switch.
             foreground_thread, _ = win32process.GetWindowThreadProcessId(foreground_handle)
             target_thread, _ = win32process.GetWindowThreadProcessId(target_handle)
+            current_tid = ctypes.windll.kernel32.GetCurrentThreadId()
 
             if not foreground_thread or not target_thread or foreground_thread == target_thread:
                 win32gui.SetForegroundWindow(target_handle)
@@ -540,10 +554,12 @@ class Desktop:
 
             ctypes.windll.user32.AllowSetForegroundWindow(-1)
 
-            attached = False
+            attached_threads = []
             try:
-                win32process.AttachThreadInput(foreground_thread, target_thread, True)
-                attached = True
+                for thread in (foreground_thread, target_thread):
+                    if thread and thread != current_tid:
+                        win32process.AttachThreadInput(current_tid, thread, True)
+                        attached_threads.append(thread)
 
                 win32gui.SetForegroundWindow(target_handle)
                 win32gui.BringWindowToTop(target_handle)
@@ -559,8 +575,8 @@ class Desktop:
                 )
 
             finally:
-                if attached:
-                    win32process.AttachThreadInput(foreground_thread, target_thread, False)
+                for tid in reversed(attached_threads):
+                    win32process.AttachThreadInput(current_tid, tid, False)
 
         except Exception as e:
             logger.exception(f"Failed to bring window to top: {e}")


### PR DESCRIPTION
## Problem

When using Windows-MCP from Claude Code (running inside Windows Terminal) to maximize a background window, Claude typically:

1. Calls `App(mode="switch")` to bring the target window to the foreground
2. Calls `Shortcut` to send `Win+Up` to maximize the window

However, after step 1, the target window is only brought to the front **visually** — the keyboard focus remains on the previous foreground window. This is evident from the minimize/maximize/close buttons in the title bar appearing **grayed out**, indicating the window is not truly activated. As a result, the subsequent `Win+Up` shortcut is delivered to the wrong window (the previously focused one), and the intended window is never maximized.

https://github.com/user-attachments/assets/6979cbb1-73c4-4b4b-b6c5-db72b043d2ed

## Root Cause

The `bring_window_to_top` method previously called `AttachThreadInput(foreground_thread, target_thread, True)`, attaching the foreground window's thread directly to the target window's thread. However, `SetForegroundWindow` is called from the MCP server's own thread — which was **not** attached to either of these threads.

Windows enforces strict rules on which thread is allowed to change the foreground window. One key criterion is that the calling process must have **"received the last input event"**. Since the MCP thread was not attached to the input queues of the foreground or target threads, it did not inherit this eligibility. Windows would then partially honor the request — moving the window to the top of the Z-order — but **refuse to transfer keyboard focus**, resulting in the observed behavior.

## Fix

Instead of attaching `foreground_thread ↔ target_thread`, we now:

1. Obtain the current MCP thread ID via `GetCurrentThreadId()`
2. Attach `current_tid` to **both** the foreground thread and the target thread
3. Call `SetForegroundWindow` / `BringWindowToTop` / `SetWindowPos` as before
4. Detach in reverse order in a `finally` block

By attaching the MCP thread to both threads, it shares their input state and inherits the eligibility to change the foreground window. This ensures that both the Z-order **and** keyboard focus are correctly transferred to the target window.

## Changes

- `src/windows_mcp/desktop/service.py`
  - `bring_window_to_top`: use `GetCurrentThreadId()` and attach the MCP thread to both foreground and target threads, instead of cross-attaching the two external threads
  - Added detailed comments explaining the rationale behind the approach
