### PR TITLE
fix: import _INPUTUnion from enums to fix NameError

### DIFF
--- a/src/windows_mcp/uia/core.py
+++ b/src/windows_mcp/uia/core.py
@@ -44,6 +44,7 @@ ProcessTime = time.perf_counter  # this returns nearly 0 when first call it if p
 ProcessTime()  # need to call it once if python version <= 3.6
 TreeNode = Any
 from .enums import *  # noqa: E402
+from .enums import _INPUTUnion
 
 
 class _AutomationClient:


### PR DESCRIPTION
When testing the `Type` tool discussed in #106 , I ran into an issue:

`Error calling tool 'Type': name '_INPUTUnion' is not defined`

The reason is that `from .enums import *` does not import names starting with an underscore, so `_INPUTUnion` is not available in scope. I’ve opened this small PR to fix this by explicitly importing it:

`from .enums import _INPUTUnion`