### PR TITLE
fix: resolve Known Folder GUID paths before launching apps

### DIFF
--- a/src/windows_mcp/desktop/service.py
+++ b/src/windows_mcp/desktop/service.py
@@ -1,4 +1,4 @@
-from windows_mcp.desktop.utils import ps_quote, ps_quote_for_xml
+from windows_mcp.desktop.utils import ps_quote, ps_quote_for_xml, resolve_known_folder_guid_path
 from windows_mcp.vdm.core import (
     get_all_desktops,
     get_current_desktop,
@@ -477,8 +477,9 @@ class Desktop:
 
         pid = 0
         if os.path.exists(appid) or "\\" in appid:
-            safe = ps_quote(appid)
-            command = f"Start-Process {safe} -PassThru | Select-Object -ExpandProperty Id"
+            exe_path = resolve_known_folder_guid_path(appid)
+            safe_exe_path = ps_quote(exe_path)
+            command = f"Start-Process {safe_exe_path} -PassThru | Select-Object -ExpandProperty Id"
             response, status = self.execute_command(command)
             if status == 0 and response.strip().isdigit():
                 pid = int(response.strip())

--- a/src/windows_mcp/desktop/utils.py
+++ b/src/windows_mcp/desktop/utils.py
@@ -1,6 +1,11 @@
 """Desktop utilities. Centralized input sanitization for PowerShell commands."""
 
+import os
+import re
 from xml.sax.saxutils import escape as xml_escape
+
+import pywintypes
+from win32com.shell import shell
 
 
 def ps_quote(value: str) -> str:
@@ -12,3 +17,38 @@ def ps_quote_for_xml(value: str) -> str:
     """XML-escape then ps_quote. Use for values in XML passed to PowerShell."""
     escaped = xml_escape(value, {'"': '&quot;', "'": '&apos;'})
     return ps_quote(escaped)
+
+
+_GUID_PATH_RE = re.compile(r"^\{([0-9A-Fa-f-]{36})}(?:\\(.*))?$")
+
+
+def resolve_known_folder_guid_path(path_text: str) -> str:
+    """Resolve a Windows Known Folder GUID path to an absolute filesystem path.
+
+    Some Start Menu shortcuts store their target as a GUID-based path such as
+    ``{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\msinfo32.exe``,
+    where the leading ``{...}`` is a Known Folder ID (e.g. the Windows directory).
+    ``Start-Process`` cannot launch these paths directly, so this function calls
+    ``SHGetKnownFolderPath`` to resolve the GUID to its actual location.
+
+    Args:
+        path_text: A raw path string, possibly prefixed with a Known Folder GUID.
+
+    Returns:
+        The resolved absolute path if the GUID is valid, or *path_text* unchanged
+        if it does not match the ``{GUID}\\...`` pattern or the GUID is unrecognised.
+    """
+    m = _GUID_PATH_RE.match(path_text)
+    if not m:
+        return path_text
+
+    guid_text = "{" + m.group(1) + "}"
+    rest = m.group(2)
+    try:
+        folder_id = pywintypes.IID(guid_text)
+        base = shell.SHGetKnownFolderPath(folder_id, 0, 0)
+    except Exception:
+        # If the GUID is not a known folder id, just return the original text
+        return path_text
+
+    return base if not rest else os.path.join(base, rest)


### PR DESCRIPTION
## Summary

- Fix `App` tool failing to launch apps whose AppID uses a Known Folder GUID path (e.g. `{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\msinfo32.exe`)
- Add `resolve_known_folder_guid_path()` utility that calls `SHGetKnownFolderPath` to resolve GUID prefixes to real filesystem paths before passing them to `Start-Process`

## Problem

When using the `App` tool in `launch` mode to start certain applications (e.g. System Information, Bandizip, ...), the following error occurs:

```
This command cannot be run due to the error: An error occurred trying to start process
'{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\msinfo32.exe' ...
```

<img width="1652" height="256" alt="image" src="https://github.com/user-attachments/assets/a97d47f5-5639-4398-ba74-31af295b90c9" />

<img width="1588" height="572" alt="image" src="https://github.com/user-attachments/assets/f415cde5-9c36-474b-8f53-8d5aac147ca0" />

<img width="1563" height="604" alt="image" src="https://github.com/user-attachments/assets/fdd3fc56-0820-4028-b920-33232b87d9d4" />

On Windows, certain app entries may contain a path-like string prefixed with a [Known Folder GUID](https://learn.microsoft.com/en-us/windows/win32/shell/known-folders), for example:

```
{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\msinfo32.exe
```

This value is not a normal filesystem path, so passing it directly to `Start-Process` will cause startup failures.

## Solution

Resolve the GUID prefix via the Win32 `SHGetKnownFolderPath` API before invoking `Start-Process`. For example:

| Before (raw AppID) | After (resolved) |
|---|---|
| `{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\msinfo32.exe` | `C:\Windows\System32\msinfo32.exe` |

If the path does not match the `{GUID}\...` pattern or the GUID is unrecognised, the original value is returned unchanged, so existing behaviour is unaffected.