### PR TITLE
fix: validate app ID via shell:AppsFolder instead of string check

### DIFF
--- a/src/windows_mcp/desktop/service.py
+++ b/src/windows_mcp/desktop/service.py
@@ -465,6 +465,16 @@ class Desktop:
                 else:
                     return response
 
+    def _check_app_exists(self, app_id: str) -> bool:
+        """Check if an app with the given AppID exists in shell:AppsFolder."""
+        safe_app_id = ps_quote(app_id)
+        command = (
+            f"$folder = (New-Object -ComObject Shell.Application).NameSpace('shell:AppsFolder'); "
+            f"if ($folder) {{ [bool]$folder.ParseName({safe_app_id}) }} else {{ $false }}"
+        )
+        response, status = self.execute_command(command)
+        return status == 0 and response.strip().lower() == "true"
+
     def launch_app(self, name: str) -> tuple[str, int, int]:
         apps_map = self.get_apps_from_start_menu()
         matched_app = process.extractOne(name, apps_map.keys(), score_cutoff=70)
@@ -484,10 +494,7 @@ class Desktop:
             if status == 0 and response.strip().isdigit():
                 pid = int(response.strip())
         else:
-            # Validate appid format (allow UWP IDs like Microsoft.WindowsNotepad_...!App)
-            # Chars to ignore for validation: \ , _ , . , - , !
-            validation_id = appid.replace("\\", "").replace("_", "").replace(".", "").replace("-", "").replace("!", "")
-            if not validation_id.isalnum():
+            if not self._check_app_exists(appid):
                 return (f"Invalid app identifier: {appid}", 1, 0)
             
             safe = ps_quote(f"shell:AppsFolder\\{appid}")


### PR DESCRIPTION
## Problem

The previous app ID validation in `launch_app` was too simplistic — it stripped a hardcoded set of special characters (`\`, `_`, `.`, `-`, `!`) and then checked whether the remainder was purely alphanumeric (`isalnum()`). This approach suffered from both false negatives and false positives:

- **False negatives**: Legitimate app IDs containing characters not in the whitelist (e.g. `Microsoft.AutoGenerated.{525860DE-BA83-3DA3-C7D9-9E4A0AEA596C}`) would be incorrectly rejected.
- **False positives**: Any arbitrary string composed of alphanumeric characters plus the whitelisted special characters would pass validation, even if no such application exists on the system.

## Solution

Replace the string-format heuristic with an actual lookup against the Windows shell. A new `_is_valid_app_id` method queries the `shell:AppsFolder` COM object via `Shell.Application.NameSpace('shell:AppsFolder').ParseName(appId)` to determine whether the app ID corresponds to a real installed application. This eliminates both false positives and false negatives.

## Changes

- Add `_is_valid_app_id` method that queries `shell:AppsFolder` to verify the app ID exists
- Remove the old character-stripping validation logic from `launch_app`