### PR TITLE
feat: replace screenshot_size with screenshot_original_size to fix mouse coordinate mismatch

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -78,7 +78,7 @@
     },
     {
       "name": "Screenshot",
-      "description": "Captures a fast screenshot-first desktop snapshot with cursor position, active/open windows, and an image. Skips UI tree extraction for speed and should be the default first call when you mainly need visual context. Supports display=[0] or display=[0,1] to limit capture to specific screens."
+      "description": "Captures a fast screenshot-first desktop snapshot with cursor position, active/open windows, and an image. Skips UI tree extraction for speed and should be the default first call when you mainly need visual context. Supports display=[0] or display=[0,1] to limit capture to specific screens. Note: the returned image may be downscaled for efficiency; when it is, multiply image coordinates by the ratio of original size to displayed size to get the actual screen coordinates for mouse actions (Click, Move, etc.)."
     },
     {
       "name": "Snapshot",

--- a/src/windows_mcp/desktop/service.py
+++ b/src/windows_mcp/desktop/service.py
@@ -220,7 +220,7 @@ class Desktop:
             region_filter_ms = (perf_counter() - stage_started_at) * 1000
             stage_started_at = perf_counter()
 
-        screenshot_size = None
+        screenshot_original_size = None
         if use_vision:
             if use_annotation:
                 nodes = tree_state.interactive_nodes
@@ -232,6 +232,8 @@ class Desktop:
                 )
             else:
                 screenshot = self.get_screenshot(capture_rect=capture_rect)
+
+            screenshot_original_size = Size(width=screenshot.width, height=screenshot.height)
 
             if profile_enabled:
                 screenshot_capture_ms = (perf_counter() - stage_started_at) * 1000
@@ -260,8 +262,6 @@ class Desktop:
                 screenshot_resize_ms = (perf_counter() - stage_started_at) * 1000
                 stage_started_at = perf_counter()
 
-            screenshot_size = Size(width=screenshot.width, height=screenshot.height)
-
             if as_bytes:
                 buffered = io.BytesIO()
                 screenshot.save(buffered, format="PNG", optimize=True, compress_level=6)
@@ -277,7 +277,7 @@ class Desktop:
             all_desktops=all_desktops,
             screenshot=screenshot,
             cursor_position=cursor_position,
-            screenshot_size=screenshot_size,
+            screenshot_original_size=screenshot_original_size,
             screenshot_region=screenshot_region,
             screenshot_displays=display_indices,
             tree_state=tree_state,

--- a/src/windows_mcp/desktop/views.py
+++ b/src/windows_mcp/desktop/views.py
@@ -62,7 +62,7 @@ class DesktopState:
     windows: list[Window]
     screenshot: Image | None = None
     cursor_position: tuple[int, int] | None = None
-    screenshot_size: Size | None = None
+    screenshot_original_size: Size | None = None
     screenshot_region: BoundingBox | None = None
     screenshot_displays: list[int] | None = None
     screenshot_backend: str | None = None

--- a/src/windows_mcp/tools/_snapshot_helpers.py
+++ b/src/windows_mcp/tools/_snapshot_helpers.py
@@ -129,8 +129,13 @@ def build_snapshot_response(
     screenshot_bytes = capture_result["screenshot_bytes"]
 
     metadata_text = f"Cursor Position: {desktop_state.cursor_position}\n"
-    if desktop_state.screenshot_size:
-        metadata_text += f"Screenshot Resolution: {desktop_state.screenshot_size.to_string()}\n"
+    if desktop_state.screenshot_original_size:
+        metadata_text += (
+            f"Screenshot Original Size: {desktop_state.screenshot_original_size.to_string()}"
+            " (the screenshot may be downscaled; multiply image coordinates by"
+            f" the ratio of original size to displayed size to get actual screen coordinates"
+            " for click, move and other mouse actions)\n"
+        )
     if desktop_state.screenshot_region:
         metadata_text += (
             f"Screenshot Region: {desktop_state.screenshot_region.xyxy_to_string()}\n"

--- a/src/windows_mcp/tools/snapshot.py
+++ b/src/windows_mcp/tools/snapshot.py
@@ -69,7 +69,7 @@ def register(mcp, *, get_desktop, get_analytics):
 
     @mcp.tool(
         name='Screenshot',
-        description="Captures a fast screenshot-first desktop snapshot with cursor position, desktop/window summaries, and an image. This path skips UI tree extraction for speed. Use Snapshot when you need interactive element ids, scrollable regions, or browser DOM extraction.",
+        description="Captures a fast screenshot-first desktop snapshot with cursor position, desktop/window summaries, and an image. This path skips UI tree extraction for speed. Use Snapshot when you need interactive element ids, scrollable regions, or browser DOM extraction. Note: the returned image may be downscaled for efficiency; when it is, multiply image coordinates by the ratio of original size to displayed size to get the actual screen coordinates for mouse actions (Click, Move, etc.).",
         annotations=ToolAnnotations(
             title="Screenshot",
             readOnlyHint=True,

--- a/tests/test_snapshot_display_filter.py
+++ b/tests/test_snapshot_display_filter.py
@@ -246,11 +246,11 @@ class TestDisplayFiltering:
             all_desktops=[{"name": "Desktop 1"}],
             active_window=None,
             windows=[],
-            screenshot_size=Size(width=1920, height=1080),
+            screenshot_original_size=Size(width=1920, height=1080),
             screenshot_region=make_box(1920, 0, 3840, 1080),
             screenshot_displays=[1],
         )
-        assert state.screenshot_size.to_string() == "(1920,1080)"
+        assert state.screenshot_original_size.to_string() == "(1920,1080)"
         assert state.screenshot_region.xyxy_to_string() == "(1920,0,3840,1080)"
         assert state.screenshot_displays == [1]
 
@@ -284,7 +284,7 @@ class TestDisplayFiltering:
         assert state.tree_state.root_node.bounding_box == desktop.tree.screen_box
         assert state.tree_state.interactive_nodes == []
         assert state.tree_state.scrollable_nodes == []
-        assert state.screenshot_size.to_string() == "(800,600)"
+        assert state.screenshot_original_size.to_string() == "(800,600)"
 
     def test_get_state_rejects_dom_without_ui_tree(self, desktop):
         desktop.tree = MagicMock()
@@ -334,7 +334,7 @@ class TestSnapshotTools:
             windows=[],
             screenshot=Image.new("RGB", (640, 480), "white"),
             cursor_position=(25, 30),
-            screenshot_size=Size(width=640, height=480),
+            screenshot_original_size=Size(width=640, height=480),
             screenshot_region=make_box(0, 0, 640, 480),
             screenshot_displays=[0],
             tree_state=TreeState(),


### PR DESCRIPTION
## Problem

Some models — Claude Opus in particular — tend to rely on the Screenshot tool (rather than Snapshot) to decide where to click or move the mouse. The Screenshot tool returns a `screenshot_size` field in its response metadata representing the resolution of the image.

However, many LLM servers (e.g. Claude.ai) automatically compress or resize images before passing them to the model in order to reduce token usage. This means the image the model actually receives may be smaller than what `screenshot_size` indicates. When the model reads coordinates directly from the image and passes them to `Click` or `Move` without accounting for this discrepancy, the resulting positions are wrong — often off by a consistent scale factor — causing clicks to land in entirely unintended locations.

For example: the physical screen is 3840×2160, windows-mcp caps the screenshot to 1920×1080, and the LLM server further compresses it to 1024×576. A control appearing at `(200, 200)` in the received image is actually at `(750, 750)` on screen — but the model clicks `(200, 200)` always.

## Root Cause

`screenshot_size` recorded the post-resize resolution on the **server side** (i.e. after windows-mcp's own downscaling cap). It said nothing about the size of the image the model actually received, and gave the model no guidance on how to reconcile the two. This made the field actively misleading.

## Solution

- **Remove `screenshot_size`** from `DesktopState` and the response metadata.
- **Introduce `screenshot_original_size`**, captured immediately after the screenshot is taken, before any server-side downscaling. This represents the true screen coordinate space.
- **Attach an inline instruction** to the `screenshot_original_size` metadata field, explaining to the model that:
  - The image it receives may have been further resized by the LLM server.
  - Before performing any mouse action (Click, Move, etc.), it must compare the actual received image dimensions against `screenshot_original_size`, compute the scale ratio, and apply it to convert image-space coordinates back to screen-space coordinates.
- **Update the Screenshot tool description** (in both `snapshot.py` and `manifest.json`) to make this requirement explicit upfront.

## Changes

- `src/windows_mcp/desktop/views.py` — replace `screenshot_size: Size | None` with `screenshot_original_size: Size | None`
- `src/windows_mcp/desktop/service.py` — capture `screenshot_original_size` before the resize step instead of after
- `src/windows_mcp/tools/_snapshot_helpers.py` — update metadata output to emit `screenshot_original_size` with coordinate-scaling guidance
- `src/windows_mcp/tools/snapshot.py` — update Screenshot tool description
- `manifest.json` — sync Screenshot tool description
- `tests/test_snapshot_display_filter.py` — update tests to use the new field name
