### PR TITLE
fix: suppress ANSI escape sequences in PowerShell output via NO_COLOR

### DIFF
--- a/src/windows_mcp/desktop/service.py
+++ b/src/windows_mcp/desktop/service.py
@@ -381,6 +381,10 @@ class Desktop:
             )
             encoded = base64.b64encode(utf8_command.encode("utf-16le")).decode("ascii")
             env = os.environ.copy()
+            # NO_COLOR suppresses ANSI escape sequences in pwsh 7.2+ (and many other CLI tools).
+            # PS5.1 has no ANSI output, so this is harmlessly ignored there.
+            # https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_ansi_terminals#disabling-ansi-output
+            env["NO_COLOR"] = "1"
 
             # Rebuild PATH and PATHEXT from registry so system executables (e.g. OpenSSH at
             # C:\Windows\System32\OpenSSH) are discoverable without requiring absolute paths.


### PR DESCRIPTION
## Summary

PowerShell 7.2+ (pwsh) [can emit ANSI color escape sequences in its output](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_ansi_terminals?view=powershell-7.6#disabling-ansi-output) (`\x1b[0m`, `\x1b[32;1m`, `\x1b[44;1m`, ...), which makes the captured text harder to read and increase token consumption. This PR sets `NO_COLOR=1` in the subprocess environment so that pwsh 7.2+ disables ANSI formatting automatically, without touching the command string itself.

<img width="1517" height="815" alt="image" src="https://github.com/user-attachments/assets/07191757-bd34-4ac1-93df-9d90aac0c467" />

## Changes

- **`src/windows_mcp/desktop/service.py`**
  - Set `env["NO_COLOR"] = "1"` on the subprocess environment immediately after `os.environ.copy()`, before the PowerShell process is spawned.

## Why `NO_COLOR`

- Honoured natively by pwsh 7.2+ to disable all ANSI formatting.
- Silently ignored by older Windows PowerShell, which never emits ANSI sequences anyway.
- Also respected by many other CLI tools that may be invoked inside the PowerShell session.