### PR TITLE
fix: remove Unicode Private Use Area characters to prevent rendering issues

### DIFF
--- a/src/windows_mcp/desktop/utils.py
+++ b/src/windows_mcp/desktop/utils.py
@@ -1,4 +1,4 @@
-"""Desktop utilities. Centralized input sanitization for PowerShell commands."""
+"""Desktop utilities. Input sanitization and text processing helpers."""
 
 import os
 import re
@@ -7,6 +7,12 @@ from xml.sax.saxutils import escape as xml_escape
 import pywintypes
 from win32com.shell import shell
 
+__all__ = [
+    "ps_quote",
+    "ps_quote_for_xml",
+    "resolve_known_folder_guid_path",
+    "remove_private_use_chars",
+]
 
 def ps_quote(value: str) -> str:
     """Wrap value in PowerShell single-quoted string literal (escapes ' as '')."""
@@ -52,3 +58,17 @@ def resolve_known_folder_guid_path(path_text: str) -> str:
         return path_text
 
     return base if not rest else os.path.join(base, rest)
+
+
+_PRIVATE_USE_RE = re.compile(
+    r'['
+    r'\uE000-\uF8FF'          # BMP Private Use Area
+    r'\U000F0000-\U000FFFFD'  # Supplementary Private Use Area-A
+    r'\U00100000-\U0010FFFD'  # Supplementary Private Use Area-B
+    r']+'
+)
+
+
+def remove_private_use_chars(text: str) -> str:
+    """Remove Unicode Private Use Area characters that may cause rendering issues."""
+    return _PRIVATE_USE_RE.sub('', text)

--- a/src/windows_mcp/tools/_snapshot_helpers.py
+++ b/src/windows_mcp/tools/_snapshot_helpers.py
@@ -12,6 +12,8 @@ import time
 from fastmcp.utilities.types import Image
 from textwrap import dedent
 from windows_mcp.desktop.service import Desktop, Size
+from windows_mcp.desktop.utils import remove_private_use_chars
+
 
 logger = logging.getLogger(__name__)
 
@@ -127,6 +129,12 @@ def build_snapshot_response(
     active_desktop = capture_result["active_desktop"]
     all_desktops = capture_result["all_desktops"]
     screenshot_bytes = capture_result["screenshot_bytes"]
+
+    # Some applications (e.g. VS Code) embed Unicode Private Use Area characters in the
+    # Automation Element Name property of certain UI elements (e.g. navigation bar items in VS Code).
+    # These characters can cause display issues, so we strip them out before rendering.
+    interactive_elements = remove_private_use_chars(interactive_elements)
+    scrollable_elements = remove_private_use_chars(scrollable_elements)
 
     metadata_text = f"Cursor Position: {desktop_state.cursor_position}\n"
     if desktop_state.screenshot_original_size:

--- a/src/windows_mcp/tree/views.py
+++ b/src/windows_mcp/tree/views.py
@@ -9,8 +9,8 @@ import json
 @dataclass
 class TreeState:
     status: bool = True
-    root_node: "TreeElementNode" | None = None
-    dom_node: "ScrollElementNode" | None = None
+    root_node: "TreeElementNode | None" = None
+    dom_node: "ScrollElementNode | None" = None
     interactive_nodes: list["TreeElementNode"] = field(default_factory=list)
     scrollable_nodes: list["ScrollElementNode"] = field(default_factory=list)
     dom_informative_nodes: list["TextElementNode"] = field(default_factory=list)

--- a/tests/test_desktop_utils.py
+++ b/tests/test_desktop_utils.py
@@ -1,0 +1,38 @@
+from windows_mcp.desktop.utils import remove_private_use_chars
+
+
+class TestRemovePrivateUseChars:
+    def test_no_private_use_chars(self):
+        assert remove_private_use_chars("hello world") == "hello world"
+
+    def test_empty_string(self):
+        assert remove_private_use_chars("") == ""
+
+    def test_bmp_private_use_area(self):
+        """U+E000..U+F8FF (Basic Multilingual Plane private use area)."""
+        assert remove_private_use_chars("abc\uE000de\ueab6f") == "abcdef"
+        assert remove_private_use_chars("\uE001\uF8FF") == ""
+
+    def test_supplementary_private_use_area_a(self):
+        """U+F0000..U+FFFFD (Supplementary Private Use Area-A)."""
+        assert remove_private_use_chars("x\U000F0000y") == "xy"
+        assert remove_private_use_chars("\U000FFFFD") == ""
+
+    def test_supplementary_private_use_area_b(self):
+        """U+100000..U+10FFFD (Supplementary Private Use Area-B)."""
+        assert remove_private_use_chars("x\U00100000y") == "xy"
+        assert remove_private_use_chars("\U0010FFFD") == ""
+
+    def test_consecutive_private_use_chars(self):
+        assert remove_private_use_chars("\uE000\uE001\uE002") == ""
+
+    def test_mixed_content(self):
+        text = "File\uE001Name\uE002.txt"
+        assert remove_private_use_chars(text) == "FileName.txt"
+
+    def test_preserves_non_private_unicode(self):
+        text = "日本語テスト 🎉 café"
+        assert remove_private_use_chars(text) == text
+
+    def test_only_private_use_chars(self):
+        assert remove_private_use_chars("\uE000\uF8FF\U000F0000\U0010FFFD") == ""


### PR DESCRIPTION
## Summary

As discussed in #117, some applications (e.g. VS Code) embed Unicode Private Use Area (PUA) characters (`U+E000..U+F8FF`, `U+F0000..U+FFFFD`, `U+100000..U+10FFFD`) in the Automation Element `Name` property of certain UI elements — for instance, icon-font glyphs in the navigation bar.

These characters serve no informational purpose in the Snapshot output but can:

- Cause rendering issues on the client side (displayed as tofu/replacement glyphs)
- Waste tokens when sent to LLMs

This PR adds a `remove_private_use_chars` utility that strips all PUA characters from the interactive and scrollable element text before returning Snapshot results.

## Changes

- **`src/windows_mcp/desktop/utils.py`** — Add `remove_private_use_chars()` with a pre-compiled regex covering all three Unicode PUA blocks; update module docstring and `__all__`
- **`src/windows_mcp/tools/_snapshot_helpers.py`** — Apply `remove_private_use_chars` to `interactive_elements` and `scrollable_elements` in `build_snapshot_response`
- **`src/windows_mcp/tree/views.py`** — Fix type annotation style (`"X" | None` → `"X | None"`)
- **`tests/test_desktop_utils.py`** — Add tests covering BMP PUA, Supplementary PUA-A/B, mixed content, and non-PUA Unicode preservation