### PR TITLE
fix: handle AttachThreadInput Access Denied for elevated processes

### DIFF
--- a/src/windows_mcp/desktop/service.py
+++ b/src/windows_mcp/desktop/service.py
@@ -665,8 +665,17 @@ class Desktop:
             try:
                 for thread in (foreground_thread, target_thread):
                     if thread and thread != current_tid:
-                        win32process.AttachThreadInput(current_tid, thread, True)
-                        attached_threads.append(thread)
+                        try:
+                            win32process.AttachThreadInput(current_tid, thread, True)
+                            attached_threads.append(thread)
+                        except Exception as e:
+                            # AttachThreadInput fails with Access Denied for elevated
+                            # processes (e.g. Settings, Task Manager). Skip the attach
+                            # and still attempt SetForegroundWindow below.
+                            logger.debug(
+                                f"AttachThreadInput failed for thread {thread} "
+                                f"(likely elevated process), skipping: {e}"
+                            )
 
                 win32gui.SetForegroundWindow(target_handle)
                 win32gui.BringWindowToTop(target_handle)


### PR DESCRIPTION
## Summary

- `bring_window_to_top` now gracefully handles `AttachThreadInput` failures when targeting elevated (high-integrity) processes such as **Settings** and **Task Manager**
- Instead of aborting the entire focus-switch flow, the error is caught and logged, and the method continues to attempt `SetForegroundWindow` / `BringWindowToTop` / `SetWindowPos`

## Problem

When `bring_window_to_top` is called with a window handle belonging to an elevated process (e.g. Windows Settings, Task Manager), `win32process.AttachThreadInput` raises an **Access Denied** exception due to Windows UIPI (User Interface Privilege Isolation). This causes the entire window-switching operation to fail, even though the subsequent `SetForegroundWindow` call can still bring the window to the foreground without the thread attach.

## Solution

Wrap the `AttachThreadInput` call in a `try/except` block so that:

1. If attach succeeds (normal-privilege windows), behavior is unchanged.
2. If attach fails (elevated windows), the failure is logged at `DEBUG` level with the exception details, and the flow continues to call `SetForegroundWindow` + `BringWindowToTop` + `SetWindowPos`.

> **Note:** Without a successful `AttachThreadInput`, the target window will be brought to the foreground visually, but keyboard focus may not transfer. Full control of elevated windows requires running the MCP server itself with administrator privileges.

## Changed files

- `src/windows_mcp/desktop/service.py` — `bring_window_to_top`: added per-thread `try/except` around `AttachThreadInput`
