### PR TITLE
fix: add MSIX package app path detection for Claude

### DIFF
--- a/src/windows_mcp/paths.py
+++ b/src/windows_mcp/paths.py
@@ -1,0 +1,94 @@
+"""Resolve Claude Desktop data directories across installation types.
+
+When Claude Desktop is installed as a Windows Package App (MSIX, e.g. via
+Microsoft Store), Windows virtualizes ``%APPDATA%`` into a per-package
+location::
+
+    %LOCALAPPDATA%\\Packages\\<PackageFamilyName>\\LocalCache\\Roaming\\Claude
+
+The standard (non-packaged) installation uses::
+
+    %APPDATA%\\Claude
+
+This module probes both locations and returns the first one that exists.
+"""
+
+from pathlib import Path
+import glob
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+# Known MSIX package-family prefix for Claude Desktop.  The suffix after the
+# underscore is a publisher-id hash that is stable across versions.
+_CLAUDE_PACKAGE_PREFIX = "Claude_"
+
+
+def get_claude_data_dir() -> Path | None:
+    """Return the Claude Desktop data directory, or ``None`` if not found.
+
+    Resolution order:
+
+    1. **MSIX path** - ``%LOCALAPPDATA%\\Packages\\Claude_*\\LocalCache\\Roaming\\Claude``
+    2. **Standard path** - ``%APPDATA%\\Claude``
+
+    Returns ``None`` when neither location exists (Claude may not be installed).
+    """
+    msix_dir = _find_msix_claude_dir()
+    if msix_dir is not None:
+        logger.info("Detected MSIX Claude Desktop data dir: %s", msix_dir)
+        return msix_dir
+
+    standard_dir = _find_standard_claude_dir()
+    if standard_dir is not None:
+        logger.info("Detected standard Claude Desktop data dir: %s", standard_dir)
+        return standard_dir
+
+    logger.debug("Claude Desktop data directory not found")
+    return None
+
+
+def get_claude_config_path() -> Path | None:
+    """Return the path to ``claude_desktop_config.json``, or ``None``."""
+    data_dir = get_claude_data_dir()
+    if data_dir is None:
+        return None
+    config_path = data_dir / "claude_desktop_config.json"
+    return config_path if config_path.is_file() else None
+
+
+def is_msix_install() -> bool:
+    """Return ``True`` if Claude Desktop appears to be an MSIX installation."""
+    return _find_msix_claude_dir() is not None
+
+
+def _find_msix_claude_dir() -> Path | None:
+    """Probe ``%LOCALAPPDATA%\\Packages`` for a Claude MSIX package directory."""
+    local_appdata = os.environ.get("LOCALAPPDATA")
+    if not local_appdata:
+        return None
+
+    packages_dir = Path(local_appdata) / "Packages"
+    if not packages_dir.is_dir():
+        return None
+
+    # Match directories like Claude_pzs8sxrjxfjjc (the publisher-id suffix
+    # varies, so we use a glob).
+    pattern = str(packages_dir / f"{_CLAUDE_PACKAGE_PREFIX}*")
+    for match in glob.glob(pattern):
+        candidate = Path(match) / "LocalCache" / "Roaming" / "Claude"
+        if candidate.is_dir():
+            return candidate
+
+    return None
+
+
+def _find_standard_claude_dir() -> Path | None:
+    """Probe ``%APPDATA%\\Claude`` for a standard (non-MSIX) install."""
+    appdata = os.environ.get("APPDATA")
+    if not appdata:
+        return None
+
+    candidate = Path(appdata) / "Claude"
+    return candidate if candidate.is_dir() else None

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,152 @@
+"""Tests for windows_mcp.paths — Claude Desktop data directory resolution."""
+
+from unittest.mock import patch
+
+from windows_mcp.paths import (
+    get_claude_config_path,
+    get_claude_data_dir,
+    is_msix_install,
+)
+
+
+class TestGetClaudeDataDir:
+    def test_returns_msix_dir_when_present(self, tmp_path):
+        """MSIX path takes priority over the standard path."""
+        local_appdata = tmp_path / "LocalAppData"
+        msix_claude = (
+            local_appdata
+            / "Packages"
+            / "Claude_pzs8sxrjxfjjc"
+            / "LocalCache"
+            / "Roaming"
+            / "Claude"
+        )
+        msix_claude.mkdir(parents=True)
+
+        # Also create the standard path to verify MSIX wins
+        appdata = tmp_path / "AppData" / "Roaming"
+        standard_claude = appdata / "Claude"
+        standard_claude.mkdir(parents=True)
+
+        env = {"LOCALAPPDATA": str(local_appdata), "APPDATA": str(appdata)}
+        with patch.dict("os.environ", env, clear=False):
+            result = get_claude_data_dir()
+
+        assert result == msix_claude
+
+    def test_returns_standard_dir_when_no_msix(self, tmp_path):
+        """Falls back to %APPDATA%\\Claude when no MSIX package is found."""
+        local_appdata = tmp_path / "LocalAppData"
+        local_appdata.mkdir()
+
+        appdata = tmp_path / "AppData" / "Roaming"
+        standard_claude = appdata / "Claude"
+        standard_claude.mkdir(parents=True)
+
+        env = {"LOCALAPPDATA": str(local_appdata), "APPDATA": str(appdata)}
+        with patch.dict("os.environ", env, clear=False):
+            result = get_claude_data_dir()
+
+        assert result == standard_claude
+
+    def test_returns_none_when_neither_exists(self, tmp_path):
+        """Returns None when Claude is not installed."""
+        local_appdata = tmp_path / "LocalAppData"
+        local_appdata.mkdir()
+        appdata = tmp_path / "AppData" / "Roaming"
+        appdata.mkdir(parents=True)
+
+        env = {"LOCALAPPDATA": str(local_appdata), "APPDATA": str(appdata)}
+        with patch.dict("os.environ", env, clear=False):
+            result = get_claude_data_dir()
+
+        assert result is None
+
+    def test_handles_missing_env_vars(self):
+        """Returns None gracefully when env vars are unset."""
+        env = {"LOCALAPPDATA": "", "APPDATA": ""}
+        with patch.dict("os.environ", env, clear=False):
+            result = get_claude_data_dir()
+
+        assert result is None
+
+    def test_matches_any_publisher_id_suffix(self, tmp_path):
+        """The glob matches Claude packages with any publisher-id hash."""
+        local_appdata = tmp_path / "LocalAppData"
+        msix_claude = (
+            local_appdata / "Packages" / "Claude_abc123xyz" / "LocalCache" / "Roaming" / "Claude"
+        )
+        msix_claude.mkdir(parents=True)
+
+        env = {"LOCALAPPDATA": str(local_appdata), "APPDATA": ""}
+        with patch.dict("os.environ", env, clear=False):
+            result = get_claude_data_dir()
+
+        assert result == msix_claude
+
+
+class TestGetClaudeConfigPath:
+    def test_returns_config_path_when_file_exists(self, tmp_path):
+        local_appdata = tmp_path / "LocalAppData"
+        msix_claude = (
+            local_appdata
+            / "Packages"
+            / "Claude_pzs8sxrjxfjjc"
+            / "LocalCache"
+            / "Roaming"
+            / "Claude"
+        )
+        msix_claude.mkdir(parents=True)
+        config_file = msix_claude / "claude_desktop_config.json"
+        config_file.write_text("{}")
+
+        env = {"LOCALAPPDATA": str(local_appdata), "APPDATA": ""}
+        with patch.dict("os.environ", env, clear=False):
+            result = get_claude_config_path()
+
+        assert result == config_file
+
+    def test_returns_none_when_config_missing(self, tmp_path):
+        local_appdata = tmp_path / "LocalAppData"
+        msix_claude = (
+            local_appdata
+            / "Packages"
+            / "Claude_pzs8sxrjxfjjc"
+            / "LocalCache"
+            / "Roaming"
+            / "Claude"
+        )
+        msix_claude.mkdir(parents=True)
+        # No config file created
+
+        env = {"LOCALAPPDATA": str(local_appdata), "APPDATA": ""}
+        with patch.dict("os.environ", env, clear=False):
+            result = get_claude_config_path()
+
+        assert result is None
+
+
+class TestIsMsixInstall:
+    def test_true_when_msix_dir_exists(self, tmp_path):
+        local_appdata = tmp_path / "LocalAppData"
+        msix_claude = (
+            local_appdata
+            / "Packages"
+            / "Claude_pzs8sxrjxfjjc"
+            / "LocalCache"
+            / "Roaming"
+            / "Claude"
+        )
+        msix_claude.mkdir(parents=True)
+
+        env = {"LOCALAPPDATA": str(local_appdata)}
+        with patch.dict("os.environ", env, clear=False):
+            assert is_msix_install() is True
+
+    def test_false_when_standard_only(self, tmp_path):
+        local_appdata = tmp_path / "LocalAppData"
+        local_appdata.mkdir()
+
+        env = {"LOCALAPPDATA": str(local_appdata)}
+        with patch.dict("os.environ", env, clear=False):
+            assert is_msix_install() is False


### PR DESCRIPTION
## Summary

- Adds a `paths` module (`src/windows_mcp/paths.py`) that resolves the Claude Desktop data directory dynamically
- Probes the MSIX package path (`%LOCALAPPDATA%\Packages\Claude_*\LocalCache\Roaming\Claude`) first, then falls back to the standard `%APPDATA%\Claude`
- Uses a glob on the package-family prefix so the publisher-id hash does not need to be hardcoded
- Exposes `get_claude_data_dir()`, `get_claude_config_path()`, and `is_msix_install()` helpers

## Test plan

- [x] 9 unit tests added covering: MSIX priority over standard path, standard fallback, missing env vars, glob matching any publisher-id suffix, config file detection, `is_msix_install()` flag
- [x] Manual verification on a Windows machine with Claude installed via MSIX (Microsoft Store)
- [ ] Manual verification on a Windows machine with Claude installed via standard installer

Closes #102