### PR TITLE
Change Dependabot update interval to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     groups:
       all-dependencies:
         patterns:


### PR DESCRIPTION
This PR changes the Dependabot update interval to daily to ensure up to date dependencies. Running it weekly could miss minor version updates, which include security and other bug fixes