### PR TITLE
Fix Snapshot crash from comtypes VARIANT marshaling on non-ASCII UI elements

### DIFF
--- a/src/windows_mcp/tree/service.py
+++ b/src/windows_mcp/tree/service.py
@@ -13,10 +13,28 @@ import os
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
+_COMTYPES_ORD_TYPEERROR_FRAGMENT = "ord() expected a character"
+_COMTYPES_AUTOMATION_PATH_FRAGMENT = "comtypes/automation.py"
+
 
 def _snapshot_profile_enabled() -> bool:
     value = os.getenv("WINDOWS_MCP_PROFILE_SNAPSHOT", "")
     return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _is_comtypes_variant_ord_typeerror(error: TypeError) -> bool:
+    message = str(error)
+    if _COMTYPES_ORD_TYPEERROR_FRAGMENT not in message:
+        return False
+
+    traceback_ref = error.__traceback__
+    while traceback_ref is not None:
+        filename = traceback_ref.tb_frame.f_code.co_filename.replace("\\", "/").lower()
+        if filename.endswith(_COMTYPES_AUTOMATION_PATH_FRAGMENT):
+            return True
+        traceback_ref = traceback_ref.tb_next
+
+    return False
 
 if TYPE_CHECKING:
     from windows_mcp.desktop.service import Desktop
@@ -572,23 +590,22 @@ class Tree:
                         # normal non-dialog children
                         self.tree_traversal(child, window_bounding_box, window_name, is_browser, interactive_nodes, scrollable_nodes, dom_interactive_nodes, dom_informative_nodes, is_dom=is_dom, is_dialog=is_dialog, element_cache_req=element_cache_req, children_cache_req=children_cache_req)
                 except TypeError as e:
-                    # comtypes VARIANT marshaling can raise TypeError when a
-                    # UI element's COM property contains a multi-byte c_char
-                    # value (e.g. non-ASCII window titles or accessibility
-                    # properties). Skip the problematic element and continue
-                    # traversing the remaining siblings.
-                    # See: https://github.com/CursorTouch/Windows-MCP/issues/147
+                    if not _is_comtypes_variant_ord_typeerror(e):
+                        raise
+
                     logger.warning(
-                        "Skipping UI element in '%s' due to COM marshaling error: %s",
+                        "Skipping UI element in '%s' due to comtypes VARIANT marshaling TypeError: %s",
                         window_name,
                         e,
                     )
                     continue
         except TypeError as e:
-            # Guard against comtypes VARIANT marshaling errors at the current
-            # node level (same root cause as the per-child guard above).
+            if not _is_comtypes_variant_ord_typeerror(e):
+                logger.error(f"Error in tree_traversal: {e}", exc_info=True)
+                raise
+
             logger.warning(
-                "Skipping subtree in '%s' due to COM marshaling error: %s",
+                "Skipping subtree in '%s' due to comtypes VARIANT marshaling TypeError: %s",
                 window_name,
                 e,
             )

--- a/tests/test_tree_service.py
+++ b/tests/test_tree_service.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock
 import pytest
 from windows_mcp.desktop.views import Size
-from windows_mcp.tree.service import Tree
+from windows_mcp.tree.service import Tree, _is_comtypes_variant_ord_typeerror
 from windows_mcp.uia import Rect
 
 
@@ -74,3 +74,30 @@ class TestIouBoundingBox:
         assert result.bottom == 1080
         assert result.width == 20
         assert result.height == 20
+
+
+def _type_error_from(filename: str) -> TypeError:
+    namespace = {}
+    code = compile("def trigger():\n    ord('hello')\n", filename, "exec")
+    exec(code, namespace)
+
+    with pytest.raises(TypeError) as exc_info:
+        namespace["trigger"]()
+
+    return exc_info.value
+
+
+class TestComtypesVariantOrdTypeError:
+    def test_matches_comtypes_automation_traceback(self):
+        error = _type_error_from(
+            "C:/Python313/Lib/site-packages/comtypes/automation.py",
+        )
+
+        assert _is_comtypes_variant_ord_typeerror(error) is True
+
+    def test_rejects_same_message_from_non_comtypes_traceback(self):
+        error = _type_error_from(
+            "C:/QA_Automation/Windows-MCP-PR/tests/helpers/fake_source.py",
+        )
+
+        assert _is_comtypes_variant_ord_typeerror(error) is False


### PR DESCRIPTION
## Description

Adds a defensive guard in `tree_traversal` so Snapshot skips the known `comtypes` `ord()` VARIANT marshaling failure instead of aborting the entire traversal.

## Motivation

On some desktops, a UI Automation property can cause `comtypes` to raise `TypeError: ord() expected a character, but string of length 5 found` while Snapshot is walking the tree. The problematic element or subtree can be skipped safely; crashing the entire Snapshot call is unnecessary.

## Changes

**File:** `src/windows_mcp/tree/service.py`

- Keep a `TypeError` guard in the per-child iteration loop to skip a single problematic child and continue with remaining siblings
- Keep a `TypeError` guard at the outer node level to skip the current subtree when the current node itself triggers the same failure
- Narrow both guards so they only swallow the known `comtypes/automation.py` `ord()` `TypeError`; unrelated `TypeError`s still follow the existing error path
- Log the window name and original exception message at `WARNING` level for diagnostics

**File:** `tests/test_tree_service.py`

- Add targeted tests for the TypeError matcher so the filter only matches the `comtypes/automation.py` traceback

## Testing

- `uv run --with pytest pytest tests/test_tree_service.py`
- `python -m py_compile src/windows_mcp/tree/service.py tests/test_tree_service.py`
- `uv run --with ruff ruff check src/windows_mcp/tree/service.py tests/test_tree_service.py`
  - This still reports the 30 pre-existing whitespace warnings already present in `src/windows_mcp/tree/service.py`; the change adds no new lint findings

## Upstream Context

- Root dependency issue: enthought/comtypes#935

## Related Issues

Fixes #147