### PR TITLE
Add debug mode and fix manifest enum key for mcpb packaging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ The codebase follows a layered service architecture under `src/windows_mcp/`:
 | `WINDOWS_MCP_SCREENSHOT_BACKEND` | `auto` | Screenshot backend: `auto`, `dxcam`, `mss`, `pillow`. Resolved in `desktop/screenshot.py`. |
 | `WINDOWS_MCP_PROFILE_SNAPSHOT` | _(off)_ | Set to `1`/`true`/`yes`/`on` to log per-stage timing for Screenshot/Snapshot. Checked in `tools/_snapshot_helpers.py` and `desktop/service.py`. |
 | `ANONYMIZED_TELEMETRY` | `true` | Set to `false` to disable PostHog telemetry. Checked in `__main__.py` and `analytics.py`. |
+| `WINDOWS_MCP_DEBUG` | `false` | Set to `1`/`true`/`yes`/`on` to enable debug mode. Checked in `config.py`. Also available as `--debug` CLI flag. |
 | `MODE` | `local` | `local` or `remote`. Remote mode proxies to windowsmcp.io. |
 | `SANDBOX_ID` | _(none)_ | Required in remote mode — VM identifier from dashboard. |
 | `API_KEY` | _(none)_ | Required in remote mode — Windows-MCP API key. |

--- a/README.md
+++ b/README.md
@@ -444,6 +444,12 @@ All variables are optional unless noted. Set them via the `env` key in `claude_d
 |---|---|---|
 | `ANONYMIZED_TELEMETRY` | `true` | Set to `false` to disable anonymous usage telemetry. No personal data, tool arguments, or outputs are ever collected regardless of this setting. |
 
+### Debug
+
+| Variable | Default | Description |
+|---|---|---|
+| `WINDOWS_MCP_DEBUG` | `false` | Set to `1`, `true`, `yes`, or `on` to enable debug mode, which sets the log level to DEBUG for verbose output. Also available as the `--debug` CLI flag. |
+
 ### Remote Mode
 
 | Variable | Default | Description |
@@ -466,7 +472,8 @@ All variables are optional unless noted. Set them via the `env` key in `claude_d
         "WINDOWS_MCP_SCREENSHOT_SCALE": "0.5",
         "WINDOWS_MCP_SCREENSHOT_BACKEND": "auto",
         "WINDOWS_MCP_PROFILE_SNAPSHOT": "false",
-        "ANONYMIZED_TELEMETRY": "true"
+        "ANONYMIZED_TELEMETRY": "true",
+        "WINDOWS_MCP_DEBUG": "false"
       }
     }
   }

--- a/manifest.json
+++ b/manifest.json
@@ -77,13 +77,7 @@
       "title": "Screenshot Backend",
       "description": "The engine used to capture screenshots. 'auto' automatically selects the fastest available backend (DXGI -> MSS -> Pillow). Use 'pillow' if you encounter capture issues.",
       "required": false,
-      "default": "auto",
-      "enum": [
-        "auto",
-        "dxcam",
-        "mss",
-        "pillow"
-      ]
+      "default": "auto"
     },
     "debug": {
       "type": "boolean",

--- a/manifest.json
+++ b/manifest.json
@@ -33,7 +33,8 @@
         "SANDBOX_ID": "${user_config.sandbox_id}",
         "API_KEY": "${user_config.api_key}",
         "WINDOWS_MCP_PROFILE_SNAPSHOT": "${user_config.profile_snapshot}",
-        "WINDOWS_MCP_SCREENSHOT_BACKEND": "${user_config.screenshot_backend}"
+        "WINDOWS_MCP_SCREENSHOT_BACKEND": "${user_config.screenshot_backend}",
+        "WINDOWS_MCP_DEBUG": "${user_config.debug}"
       }
     }
   },
@@ -83,6 +84,13 @@
         "mss",
         "pillow"
       ]
+    },
+    "debug": {
+      "type": "boolean",
+      "title": "Debug Mode",
+      "description": "Enable debug mode to provide verbose logging for troubleshooting.",
+      "required": false,
+      "default": false
     }
   },
   "tools": [

--- a/src/windows_mcp/__main__.py
+++ b/src/windows_mcp/__main__.py
@@ -1,5 +1,6 @@
 from contextlib import asynccontextmanager
 from windows_mcp.auth import AuthClient
+from windows_mcp.config import is_debug, enable_debug
 from fastmcp import FastMCP
 from dataclasses import dataclass, field
 from textwrap import dedent
@@ -59,8 +60,10 @@ def _build_local_mcp() -> FastMCP:
         try:
             watchdog.start()
             await asyncio.sleep(1)  # Simulate startup latency
+            logger.debug("Server started, entering main loop")
             yield
         finally:
+            logger.debug("Shutting down: stopping watchdog and analytics")
             if watchdog:
                 watchdog.stop()
             if analytics:
@@ -142,6 +145,7 @@ def _run_remote_mode(config: Config, transport: str, host: str, port: int) -> No
         case _:
             raise ValueError(f"Invalid transport: {transport}")
 
+
 @click.command()
 @click.option(
     "--transport",
@@ -163,20 +167,39 @@ def _run_remote_mode(config: Config, transport: str, host: str, port: int) -> No
     type=int,
     show_default=True,
 )
+@click.option(
+    "--debug",
+    help="Enable debug mode to provide verbose logging for troubleshooting.",
+    is_flag=True,
+    default=False,
+    show_default=True,
+)
+def main(transport, host, port, debug):
+    if debug:
+        enable_debug()
 
-def main(transport, host, port):
+    if is_debug():
+        logging.basicConfig(level=logging.DEBUG)
+
     config = Config(
         mode=os.getenv("MODE", Mode.LOCAL.value).lower(),
         sandbox_id=os.getenv("SANDBOX_ID", ''),
         api_key=os.getenv("API_KEY", '')
     )
-    match config.mode:
-        case Mode.LOCAL.value:
-            _run_local_mode(transport=transport, host=host, port=port)
-        case Mode.REMOTE.value:
-            _run_remote_mode(config=config, transport=transport, host=host, port=port)
-        case _:
-            raise ValueError(f"Invalid mode: {config.mode}")
+    logger.debug("Starting windows-mcp (mode=%s, transport=%s)", config.mode, transport)
+    try:
+        match config.mode:
+            case Mode.LOCAL.value:
+                _run_local_mode(transport=transport, host=host, port=port)
+            case Mode.REMOTE.value:
+                _run_remote_mode(config=config, transport=transport, host=host, port=port)
+            case _:
+                raise ValueError(f"Invalid mode: {config.mode}")
+        logger.debug("Server shut down normally")
+    except Exception:
+        logger.error("Server exiting due to unhandled exception", exc_info=True)
+        raise
+
 
 if __name__ == "__main__":
     main()

--- a/src/windows_mcp/config.py
+++ b/src/windows_mcp/config.py
@@ -1,0 +1,11 @@
+import os
+
+
+def is_debug() -> bool:
+    """Return True if debug mode is enabled via the WINDOWS_MCP_DEBUG environment variable."""
+    return os.getenv("WINDOWS_MCP_DEBUG", "false").lower() in ("1", "true", "yes", "on")
+
+
+def enable_debug() -> None:
+    """Enable debug mode by setting the WINDOWS_MCP_DEBUG environment variable."""
+    os.environ["WINDOWS_MCP_DEBUG"] = "true"


### PR DESCRIPTION
## Summary

- **Debug mode**: During recent issue investigations, we found that the default logging output was insufficient for effective troubleshooting. Additionally, there was no user-facing option to enable verbose logging. This PR introduces a debug mode that can be activated via the `--debug` CLI flag, the `WINDOWS_MCP_DEBUG` environment variable, or the Debug Mode toggle in the Claude Desktop plugin UI. When enabled, the log level is set to `DEBUG`, providing more detailed output to help diagnose issues.
  
  <img width="2088" height="1069" alt="image" src="https://github.com/user-attachments/assets/66375c2b-6c3a-4d17-a8eb-9a8c47093c61" /> 

- **Manifest fix**: When packaging with `mcpb`, the build failed with:
  ```
  ERROR: Manifest validation failed:
    - user_config.screenshot_backend: Unrecognized key(s) in object: 'enum'
  ERROR: Cannot pack extension with invalid manifest
  ```
  The current version of `mcpb` does not support the `enum` key in user config schemas (support may be introduced in a future version, but is currently on hold, see https://github.com/modelcontextprotocol/mcpb/issues/165). Removed the unsupported `enum` field from `screenshot_backend` config to unblock packaging.

## Changes

- Add `src/windows_mcp/config.py` with `is_debug()` and `enable_debug()` helpers
- Add `--debug` flag to the CLI entry point in `__main__.py`
- Add debug-level logging for server lifecycle events (startup, shutdown)
- Add `WINDOWS_MCP_DEBUG` to `manifest.json` user config and documentation (`README.md`, `CLAUDE.md`)
- Remove unsupported `enum` key from `screenshot_backend` in `manifest.json`

