### PR TITLE
fix: replace broken skill-publish workflow with plugin scanner

### DIFF
--- a/.github/workflows/hol-skill-validate.yml
+++ b/.github/workflows/hol-skill-validate.yml
@@ -1,18 +1,19 @@
-name: HOL Skill Validate
+name: Codex Plugin Scanner CI
 on:
   push:
     branches: [main, master]
   pull_request:
 
 jobs:
-  validate-skill:
+  scan-plugin:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Validate skill package
-        uses: hashgraph-online/skill-publish@4119400f6195122738899822e128c3c515b45301 # v1
+      - name: Scan Codex plugin
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@40d95e49abdd8aeb34b534461a9fa4f96cdd4d7c
         with:
-          skill-dir: .
-          mode: validate
+          plugin_dir: .
+          fail_on_severity: none

--- a/.github/workflows/hol-skill-validate.yml
+++ b/.github/workflows/hol-skill-validate.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: [main, master]
   pull_request:
+
 jobs:
   validate-skill:
     runs-on: ubuntu-latest
@@ -11,6 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Validate skill package
-        uses: hashgraph-online/skill-publish@c182a4aa4dba68fb7f3c01be4ca560dfb759ae9e # v1
+        uses: hashgraph-online/skill-publish@4119400f6195122738899822e128c3c515b45301 # v1
         with:
           skill-dir: .
+          mode: validate


### PR DESCRIPTION
Replaces the broken HOL workflow on  with the correct validator for this repo type.

Root cause:
- the existing workflow was pinned to an old  SHA, which failed immediately because it required 
- after restoring a modern  pin on this branch, the action failed correctly with 
-  is a Codex plugin repo with , not a HOL skill package

This PR switches the workflow to , which is the right validator for the assets in this repository.