### PR TITLE
fix: refresh workflow action pin

### DIFF
--- a/.github/workflows/hol-skill-validate.yml
+++ b/.github/workflows/hol-skill-validate.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Validate skill package
-        uses: hashgraph-online/skill-publish@c182a4aa4dba68fb7f3c01be4ca560dfb759ae9e # v1
+        uses: hashgraph-online/skill-publish@ee40f6501dee6e687a04c285b5b94343cbf64c42 # v1.0.9
         with:
           skill-dir: .

--- a/.github/workflows/hol-skill-validate.yml
+++ b/.github/workflows/hol-skill-validate.yml
@@ -13,4 +13,4 @@ jobs:
       - name: Validate skill package
         uses: hashgraph-online/skill-publish@ee40f6501dee6e687a04c285b5b94343cbf64c42 # v1.0.9
         with:
-          skill-dir: .
+          skill-dir: skills/windows-mcp

--- a/skills/windows-mcp/skill.json
+++ b/skills/windows-mcp/skill.json
@@ -1,0 +1,7 @@
+{
+  "name": "windows-mcp",
+  "version": "1.0.0",
+  "description": "Windows computer use from Codex via MCP.",
+  "license": "MIT",
+  "repository": "https://github.com/CursorTouch/Windows-MCP"
+}


### PR DESCRIPTION
## Summary
- update the HOL validation workflow to the current released immutable skill-publish SHA
- point validation at the actual skill package under `skills/windows-mcp`
- add the missing `skill.json` so the package is a valid HOL skill

## Testing
- verified the old pinned SHA fails validate mode with a missing API key on a clean action runtime
- verified `skill-publish@1.0.9` was released successfully
- verified the exact `skills/windows-mcp` package shape validates cleanly under the released action runtime
