### PR TITLE
fix: update skill-publish to v1 (no api-key required)

### DIFF
--- a/.github/workflows/hol-skill-validate.yml
+++ b/.github/workflows/hol-skill-validate.yml
@@ -1,0 +1,17 @@
+name: HOL Skill Validate
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+jobs:
+  validate-skill:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Validate skill package
+        uses: hashgraph-online/skill-publish@8f3c91d7d4cde7b104549e5f0cccdbb4cd7ee58d # v1
+        with:
+          skill-dir: .
+          mode: validate


### PR DESCRIPTION
Updates the HOL Skill Validate workflow to use the fixed skill-publish SHA (8f3c91d7) with mode=validate, which no longer requires api-key input.

Previously the workflow was failing because the action requires RB_API_KEY which isn't configured. This fix switches to the validated version that works without it.