### PR TITLE
docs: add WSL setup instructions for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,24 @@ npm install -g @anthropic-ai/claude-code
   ```
 
   To verify the server is registered, run `claude mcp list`. Inside Claude Code, use `/mcp` to check server status.
+
+  **WSL (Windows Subsystem for Linux)**
+
+  If you run Claude Code from WSL, the MCP server must still execute on the Windows side (it needs Windows APIs for UI automation). Use `powershell.exe` as the command to bridge WSL and Windows:
+
+  1. Install `uv` on **Windows** (from a PowerShell terminal):
+  ```powershell
+  irm https://astral.sh/uv/install.ps1 | iex
+  ```
+
+  2. From your **WSL terminal**, register the server:
+  ```shell
+  claude mcp add windows-mcp --transport stdio -s user -- powershell.exe -Command "C:\Users\<user>\.local\bin\uvx.exe windows-mcp"
+  ```
+
+  Replace `<user>` with your Windows username. The `-s user` flag makes the server available across all projects.
+
+  3. Restart Claude Code and verify with `/mcp`.
 </details>
 
 ---


### PR DESCRIPTION
## Summary
- Adds WSL (Windows Subsystem for Linux) setup instructions to the Claude Code installation section
- Documents the `powershell.exe` wrapper approach needed when running Claude Code from WSL, since Windows MCP requires Windows APIs for UI automation

## Context
When running Claude Code from WSL, the standard `uvx windows-mcp` command doesn't work because:
1. The MCP server needs Windows APIs (UIAutomation, screenshots, etc.)
2. Claude Code in WSL needs `powershell.exe` as the command to bridge to Windows
3. `uv` must be installed on the Windows side, not in WSL

The working command is:
```
claude mcp add windows-mcp --transport stdio -s user -- powershell.exe -Command "C:\Users\<user>\.local\bin\uvx.exe windows-mcp"
```

Closes #189

## Test plan
- [x] Verified this setup works on WSL2 with Claude Code connecting to Windows MCP successfully
- [x] All 20 tools (Click, Screenshot, Shell, etc.) load and appear in `/mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)