### PR TITLE
feat: add UV path override config for restricted Windows environments

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,184 +1,205 @@
 {
-  "manifest_version": "0.3",
-  "name": "Windows-MCP",
-  "version": "0.7.1",
-  "description": "MCP Server that enables Claude to interact with Windows OS",
-  "long_description": "Windows-MCP is an open-source project that enables seamless integration between AI agents and the Windows operating system. Acting as an MCP server, it bridges the gap between large language models (LLMs) and the Windows OS, allowing agents to perform tasks such as **file navigation, application control, UI interaction, QA testing, and more**.\n\n**KEY FEATURES**\n- **Seamless Windows Integration**: Interacts natively with Windows UI elements, opens applications, controls windows, simulates user input, and more.\n- **Use Any LLM (Vision Optional)**: Does not rely on traditional computer vision techniques or fine-tuned models. Works with any LLM, reducing complexity and setup time.\n- **Rich Toolset for UI Automation**: Includes tools for keyboard and mouse control, window management, and capturing window or UI state.\n- **Lightweight & Open-Source**: Minimal dependencies with full source code available under the MIT license.\n- **Customizable & Extendable**: Easily adapt or extend tools to suit custom automation workflows or AI integrations.\n- **Real-Time Interaction**: Typical latency between actions ranges from `0.2` to `0.9` seconds, depending on system load, active applications, and LLM inference speed.\n\n**MINIMUM REQUIREMENTS**\n- **Python 3.13+**\n- **UV Package Manager** — `curl -LsSf https://astral.sh/uv/install.sh | sh`\n",
-  "author": {
-    "name": "CursorTouch",
-    "url": "https://cursortouch.com/"
-  },
-  "homepage": "https://cursortouch.com/",
-  "documentation": "https://github.com/CursorTouch/Windows-MCP",
-  "icon": "assets/logo.png",
-  "screenshots": [
-    "assets/screenshots/screenshot_1.png",
-    "assets/screenshots/screenshot_2.png",
-    "assets/screenshots/screenshot_3.png"
-  ],
-  "server": {
-    "type": "python",
-    "entry_point": "src/windows_mcp/__main__.py",
-    "mcp_config": {
-      "command": "uv",
-      "args": [
-        "--directory",
-        "${__dirname}",
-        "run",
-        "windows-mcp"
-      ],
-      "env": {
-        "ANONYMIZED_TELEMETRY": "${user_config.anonymized_telemetry}",
-        "MODE": "${user_config.mode}",
-        "SANDBOX_ID": "${user_config.sandbox_id}",
-        "API_KEY": "${user_config.api_key}",
-        "WINDOWS_MCP_PROFILE_SNAPSHOT": "${user_config.profile_snapshot}",
-        "WINDOWS_MCP_SCREENSHOT_BACKEND": "${user_config.screenshot_backend}",
-        "WINDOWS_MCP_DEBUG": "${user_config.debug}"
-      }
-    }
-  },
-  "user_config": {
-    "mode": {
-      "type": "string",
-      "title": "Mode (local or remote)",
-      "description": "Set to 'local' to run directly on your machine, or 'remote' to use cloud-hosted Windows automation via windowsmcp.io. In remote mode the extension acts only as a lightweight proxy, so no local Windows automation build should be required. Remote mode requires a Sandbox ID and API Key from the dashboard at windowsmcp.io.",
-      "required": false,
-      "default": "local"
-    },
-    "sandbox_id": {
-      "type": "string",
-      "title": "Sandbox ID",
-      "description": "The sandbox/VM identifier from the windowsmcp.io. Required when mode is set to 'remote'.",
-      "required": false
-    },
-    "api_key": {
-      "type": "string",
-      "title": "API Key",
-      "description": "Your API key from the windowsmcp.io. Required when mode is set to 'remote'.",
-      "required": false
-    },
-    "anonymized_telemetry": {
-      "type": "boolean",
-      "title": "Anonymized Telemetry",
-      "description": "Windows-MCP collects basic usage data to help improve the MCP server. No personal information, tool arguments, or tool outputs are tracked.",
-      "required": false,
-      "default": true
-    },
-    "profile_snapshot": {
-      "type": "boolean",
-      "title": "Profile Snapshot Performance",
-      "description": "Enable detailed performance logging for desktop snapshots and screenshots in the server console/logs. Useful for troubleshooting latency.",
-      "required": false,
-      "default": false
-    },
-    "screenshot_backend": {
-      "type": "string",
-      "title": "Screenshot Backend",
-      "description": "The engine used to capture screenshots. 'auto' automatically selects the fastest available backend (DXGI -> MSS -> Pillow). Use 'pillow' if you encounter capture issues.",
-      "required": false,
-      "default": "auto"
-    },
-    "debug": {
-      "type": "boolean",
-      "title": "Debug Mode",
-      "description": "Enable debug mode to provide verbose logging for troubleshooting.",
-      "required": false,
-      "default": false
-    }
-  },
-  "tools": [
-    {
-      "name": "App",
-      "description": "Manages Windows applications with three modes: 'launch' (opens the prescibed application), 'resize' (adjusts the size/position of a named window or the active window if name is omitted), 'switch' (brings specific window into focus)."
-    },
-    {
-      "name": "PowerShell",
-      "description": "A comprehensive system tool for executing any PowerShell commands. Use it to navigate the file system, manage files and processes, and execute system-level operations. Capable of accessing web content, interacting with network resources, and performing complex administrative tasks."
-    },
-    {
-      "name": "FileSystem",
-      "description": "Manages file system operations with eight modes: 'read' (read text file contents), 'write' (create/overwrite/append to files), 'copy' (copy files or directories), 'move' (move or rename), 'delete' (delete files or directories), 'list' (list directory contents), 'search' (find files by glob pattern), 'info' (get metadata like size, dates, type). Relative paths are resolved from the user's Desktop folder. Use absolute paths to access other locations."
-    },
-    {
-      "name": "Screenshot",
-      "description": "Captures a fast screenshot-first desktop snapshot with cursor position, active/open windows, and an image. Skips UI tree extraction for speed and should be the default first call when you mainly need visual context. Supports display=[0] or display=[0,1] to limit capture to specific screens. Note: the returned image may be downscaled for efficiency; when it is, multiply image coordinates by the ratio of original size to displayed size to get the actual screen coordinates for mouse actions (Click, Move, etc.)."
-    },
-    {
-      "name": "Snapshot",
-      "description": "Captures complete desktop state including: system language, focused/opened windows, interactive elements (buttons, text fields, links, menus with coordinates), and scrollable areas. Use this when you need interactive element ids, scrollable regions, or browser DOM extraction with use_dom=True. Set use_vision=True to include screenshot. Set display=[0] or display=[0,1] to limit all returned Snapshot information to specific screens; omit it to keep the default full-desktop behavior."
-    },
-    {
-      "name": "Click",
-      "description": "Performs mouse clicks at specified coordinates [x, y] or passing a UI element's label/id. Supports button types: 'left' for selection/activation, 'right' for context menus, 'middle'. Supports clicks: 0=hover only (no click), 1=single click (select/focus), 2=double click (open/activate). Provide either loc or label."
-    },
-    {
-      "name": "Type",
-      "description": "Types text at specified coordinates [x, y] or passing a UI element's label/id. Set clear=True to clear existing text first, False to append. Set press_enter=True to submit after typing. Set caret_position to 'start' (beginning), 'end' (end), or 'idle' (default). Provide either loc or label."
-    },
-    {
-      "name": "Scroll",
-      "description": "Scrolls at coordinates [x, y], a UI element's label/id, or current mouse position if loc=None. Type: vertical (default) or horizontal. Direction: up/down for vertical, left/right for horizontal. wheel_times controls amount (1 wheel ≈ 3-5 lines). Use for navigating long content, lists, and web pages."
-    },
-    {
-      "name": "Move",
-      "description": "Moves mouse cursor to coordinates [x, y] or passing a UI element's label/id. Set drag=True to perform a drag-and-drop operation from the current mouse position to the target coordinates. Default (drag=False) is a simple cursor move (hover). Provide either loc or label."
-    },
-    {
-      "name": "Shortcut",
-      "description": "Executes keyboard shortcuts using key combinations separated by +. Examples: \"ctrl+c\" (copy), \"ctrl+v\" (paste), \"alt+tab\" (switch apps), \"win+r\" (Run dialog), \"win\" (Start menu), \"ctrl+shift+esc\" (Task Manager). Use for quick actions and system commands."
-    },
-    {
-      "name": "Wait",
-      "description": "Pauses execution for specified duration in seconds. Use when waiting for: applications to launch/load, UI animations to complete, page content to render, dialogs to appear, or between rapid actions. Helps ensure UI is ready before next interaction."
-    },
-    {
-      "name": "Scrape",
-      "description": "Fetch content from a URL or the active browser tab. By default, performs a lightweight HTTP request to the URL. If you need to extract text from the active tab's DOM within the viewport, ensure the page is open in a browser and use Snapshot with use_dom=True first, then the agent will handle extraction. Use Screenshot for the default fast visual inspection path."
-    },
-    {
-      "name": "MultiSelect",
-      "description": "Selects multiple items such as files, folders, or checkboxes if press_ctrl=True, or performs multiple clicks if False. Pass locs (list of coordinates) or labels (list of UI element labels/ids)."
-    },
-    {
-      "name": "MultiEdit",
-      "description": "Enters text into multiple input fields at specified coordinates locs=[[x,y,text], ...] or using labels=[[label,text], ...]. Provide either locs or labels."
-    },
-    {
-      "name": "Clipboard",
-      "description": "Manages Windows clipboard operations. Use mode=\"get\" to read current clipboard content, mode=\"set\" to set clipboard text."
-    },
-    {
-      "name": "Process",
-      "description": "Manages system processes. Use mode=\"list\" to list running processes with filtering and sorting options. Use mode=\"kill\" to terminate processes by PID or name."
-    },
-    {
-      "name": "Notification",
-      "description": "Sends a Windows toast notification with a title and message. Useful for alerting the user remotely."
-    },
-    {
-      "name": "Registry",
-      "description": "Accesses the Windows Registry. Use mode=\"get\" to read a value, mode=\"set\" to create/update a value, mode=\"delete\" to remove a value or key, mode=\"list\" to list values and sub-keys under a path."
-    }
-  ],
-  "compatibility": {
-    "platforms": [
-      "win32"
-    ],
-    "runtimes": {
-      "python": ">=3.13"
-    }
-  },
-  "keywords": [
-    "windows",
-    "automation",
-    "ai",
-    "mcp",
-    "computer-use"
-  ],
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/CursorTouch/Windows-MCP"
-  }
+    "manifest_version":  "0.3",
+    "name":  "Windows-MCP",
+    "version":  "0.7.1",
+    "description":  "MCP Server that enables Claude to interact with Windows OS",
+    "long_description":  "Windows-MCP is an open-source project that enables seamless integration between AI agents and the Windows operating system. Acting as an MCP server, it bridges the gap between large language models (LLMs) and the Windows OS, allowing agents to perform tasks such as **file navigation, application control, UI interaction, QA testing, and more**.\n\n**KEY FEATURES**\n- **Seamless Windows Integration**: Interacts natively with Windows UI elements, opens applications, controls windows, simulates user input, and more.\n- **Use Any LLM (Vision Optional)**: Does not rely on traditional computer vision techniques or fine-tuned models. Works with any LLM, reducing complexity and setup time.\n- **Rich Toolset for UI Automation**: Includes tools for keyboard and mouse control, window management, and capturing window or UI state.\n- **Lightweight \u0026 Open-Source**: Minimal dependencies with full source code available under the MIT license.\n- **Customizable \u0026 Extendable**: Easily adapt or extend tools to suit custom automation workflows or AI integrations.\n- **Real-Time Interaction**: Typical latency between actions ranges from `0.2` to `0.9` seconds, depending on system load, active applications, and LLM inference speed.\n\n**MINIMUM REQUIREMENTS**\n- **Python 3.13+**\n- **UV Package Manager** — `curl -LsSf https://astral.sh/uv/install.sh | sh`\n",
+    "author":  {
+                   "name":  "CursorTouch",
+                   "url":  "https://cursortouch.com/"
+               },
+    "homepage":  "https://cursortouch.com/",
+    "documentation":  "https://github.com/CursorTouch/Windows-MCP",
+    "icon":  "assets/logo.png",
+    "screenshots":  [
+                        "assets/screenshots/screenshot_1.png",
+                        "assets/screenshots/screenshot_2.png",
+                        "assets/screenshots/screenshot_3.png"
+                    ],
+    "server":  {
+                   "type":  "python",
+                   "entry_point":  "src/windows_mcp/__main__.py",
+                   "mcp_config":  {
+                                      "command":  "uv",
+                                      "args":  [
+                                                   "--directory",
+                                                   "${__dirname}",
+                                                   "run",
+                                                   "windows-mcp"
+                                               ],
+                                      "env":  {
+                                                  "ANONYMIZED_TELEMETRY":  "${user_config.anonymized_telemetry}",
+                                                  "MODE":  "${user_config.mode}",
+                                                  "SANDBOX_ID":  "${user_config.sandbox_id}",
+                                                  "API_KEY":  "${user_config.api_key}",
+                                                  "WINDOWS_MCP_PROFILE_SNAPSHOT":  "${user_config.profile_snapshot}",
+                                                  "WINDOWS_MCP_SCREENSHOT_BACKEND":  "${user_config.screenshot_backend}",
+                                                  "WINDOWS_MCP_DEBUG":  "${user_config.debug}",
+                                                  "UV_CACHE_DIR":  "${user_config.uv_cache_dir}",
+                                                  "UV_PYTHON_INSTALL_DIR":  "${user_config.uv_python_install_dir}",
+                                                  "UV_PROJECT_ENVIRONMENT":  "${user_config.uv_project_environment}"
+                                              }
+                                  }
+               },
+    "user_config":  {
+                        "mode":  {
+                                     "type":  "string",
+                                     "title":  "Mode (local or remote)",
+                                     "description":  "Set to \u0027local\u0027 to run directly on your machine, or \u0027remote\u0027 to use cloud-hosted Windows automation via windowsmcp.io. In remote mode the extension acts only as a lightweight proxy, so no local Windows automation build should be required. Remote mode requires a Sandbox ID and API Key from the dashboard at windowsmcp.io.",
+                                     "required":  false,
+                                     "default":  "local"
+                                 },
+                        "sandbox_id":  {
+                                           "type":  "string",
+                                           "title":  "Sandbox ID",
+                                           "description":  "The sandbox/VM identifier from the windowsmcp.io. Required when mode is set to \u0027remote\u0027.",
+                                           "required":  false
+                                       },
+                        "api_key":  {
+                                        "type":  "string",
+                                        "title":  "API Key",
+                                        "description":  "Your API key from the windowsmcp.io. Required when mode is set to \u0027remote\u0027.",
+                                        "required":  false
+                                    },
+                        "anonymized_telemetry":  {
+                                                     "type":  "boolean",
+                                                     "title":  "Anonymized Telemetry",
+                                                     "description":  "Windows-MCP collects basic usage data to help improve the MCP server. No personal information, tool arguments, or tool outputs are tracked.",
+                                                     "required":  false,
+                                                     "default":  true
+                                                 },
+                        "profile_snapshot":  {
+                                                 "type":  "boolean",
+                                                 "title":  "Profile Snapshot Performance",
+                                                 "description":  "Enable detailed performance logging for desktop snapshots and screenshots in the server console/logs. Useful for troubleshooting latency.",
+                                                 "required":  false,
+                                                 "default":  false
+                                             },
+                        "screenshot_backend":  {
+                                                   "type":  "string",
+                                                   "title":  "Screenshot Backend",
+                                                   "description":  "The engine used to capture screenshots. \u0027auto\u0027 automatically selects the fastest available backend (DXGI -\u003e MSS -\u003e Pillow). Use \u0027pillow\u0027 if you encounter capture issues.",
+                                                   "required":  false,
+                                                   "default":  "auto"
+                                               },
+                        "debug":  {
+                                      "type":  "boolean",
+                                      "title":  "Debug Mode",
+                                      "description":  "Enable debug mode to provide verbose logging for troubleshooting.",
+                                      "required":  false,
+                                      "default":  false
+                                  },
+                        "uv_cache_dir":  {
+                                             "type":  "string",
+                                             "title":  "UV Cache Directory",
+                                             "description":  "Override where UV stores downloaded packages and build artifacts. Useful when system policies (e.g., AppLocker) block running executables from the user profile directory. Leave empty to use UV\u0027s default. Docs: https://docs.astral.sh/uv/reference/environment/#uv_cache_dir",
+                                             "required":  false
+                                         },
+                        "uv_python_install_dir":  {
+                                                      "type":  "string",
+                                                      "title":  "UV Python Install Directory",
+                                                      "description":  "Override where UV installs managed Python interpreters. Useful when system policies block running executables from the user profile directory. Leave empty to use UV\u0027s default. Docs: https://docs.astral.sh/uv/reference/environment/#uv_python_install_dir",
+                                                      "required":  false
+                                                  },
+                        "uv_project_environment":  {
+                                                       "type":  "string",
+                                                       "title":  "UV Project Virtual Environment",
+                                                       "description":  "Override where UV creates this project\u0027s virtual environment instead of the default .venv directory. Useful when system policies block running executables from the user profile directory. Leave empty to use UV\u0027s default. Docs: https://docs.astral.sh/uv/reference/environment/#uv_project_environment",
+                                                       "required":  false
+                                                   }
+                    },
+    "tools":  [
+                  {
+                      "name":  "App",
+                      "description":  "Manages Windows applications with three modes: \u0027launch\u0027 (opens the prescibed application), \u0027resize\u0027 (adjusts the size/position of a named window or the active window if name is omitted), \u0027switch\u0027 (brings specific window into focus)."
+                  },
+                  {
+                      "name":  "PowerShell",
+                      "description":  "A comprehensive system tool for executing any PowerShell commands. Use it to navigate the file system, manage files and processes, and execute system-level operations. Capable of accessing web content, interacting with network resources, and performing complex administrative tasks."
+                  },
+                  {
+                      "name":  "FileSystem",
+                      "description":  "Manages file system operations with eight modes: \u0027read\u0027 (read text file contents), \u0027write\u0027 (create/overwrite/append to files), \u0027copy\u0027 (copy files or directories), \u0027move\u0027 (move or rename), \u0027delete\u0027 (delete files or directories), \u0027list\u0027 (list directory contents), \u0027search\u0027 (find files by glob pattern), \u0027info\u0027 (get metadata like size, dates, type). Relative paths are resolved from the user\u0027s Desktop folder. Use absolute paths to access other locations."
+                  },
+                  {
+                      "name":  "Screenshot",
+                      "description":  "Captures a fast screenshot-first desktop snapshot with cursor position, active/open windows, and an image. Skips UI tree extraction for speed and should be the default first call when you mainly need visual context. Supports display=[0] or display=[0,1] to limit capture to specific screens. Note: the returned image may be downscaled for efficiency; when it is, multiply image coordinates by the ratio of original size to displayed size to get the actual screen coordinates for mouse actions (Click, Move, etc.)."
+                  },
+                  {
+                      "name":  "Snapshot",
+                      "description":  "Captures complete desktop state including: system language, focused/opened windows, interactive elements (buttons, text fields, links, menus with coordinates), and scrollable areas. Use this when you need interactive element ids, scrollable regions, or browser DOM extraction with use_dom=True. Set use_vision=True to include screenshot. Set display=[0] or display=[0,1] to limit all returned Snapshot information to specific screens; omit it to keep the default full-desktop behavior."
+                  },
+                  {
+                      "name":  "Click",
+                      "description":  "Performs mouse clicks at specified coordinates [x, y] or passing a UI element\u0027s label/id. Supports button types: \u0027left\u0027 for selection/activation, \u0027right\u0027 for context menus, \u0027middle\u0027. Supports clicks: 0=hover only (no click), 1=single click (select/focus), 2=double click (open/activate). Provide either loc or label."
+                  },
+                  {
+                      "name":  "Type",
+                      "description":  "Types text at specified coordinates [x, y] or passing a UI element\u0027s label/id. Set clear=True to clear existing text first, False to append. Set press_enter=True to submit after typing. Set caret_position to \u0027start\u0027 (beginning), \u0027end\u0027 (end), or \u0027idle\u0027 (default). Provide either loc or label."
+                  },
+                  {
+                      "name":  "Scroll",
+                      "description":  "Scrolls at coordinates [x, y], a UI element\u0027s label/id, or current mouse position if loc=None. Type: vertical (default) or horizontal. Direction: up/down for vertical, left/right for horizontal. wheel_times controls amount (1 wheel ≈ 3-5 lines). Use for navigating long content, lists, and web pages."
+                  },
+                  {
+                      "name":  "Move",
+                      "description":  "Moves mouse cursor to coordinates [x, y] or passing a UI element\u0027s label/id. Set drag=True to perform a drag-and-drop operation from the current mouse position to the target coordinates. Default (drag=False) is a simple cursor move (hover). Provide either loc or label."
+                  },
+                  {
+                      "name":  "Shortcut",
+                      "description":  "Executes keyboard shortcuts using key combinations separated by +. Examples: \"ctrl+c\" (copy), \"ctrl+v\" (paste), \"alt+tab\" (switch apps), \"win+r\" (Run dialog), \"win\" (Start menu), \"ctrl+shift+esc\" (Task Manager). Use for quick actions and system commands."
+                  },
+                  {
+                      "name":  "Wait",
+                      "description":  "Pauses execution for specified duration in seconds. Use when waiting for: applications to launch/load, UI animations to complete, page content to render, dialogs to appear, or between rapid actions. Helps ensure UI is ready before next interaction."
+                  },
+                  {
+                      "name":  "Scrape",
+                      "description":  "Fetch content from a URL or the active browser tab. By default, performs a lightweight HTTP request to the URL. If you need to extract text from the active tab\u0027s DOM within the viewport, ensure the page is open in a browser and use Snapshot with use_dom=True first, then the agent will handle extraction. Use Screenshot for the default fast visual inspection path."
+                  },
+                  {
+                      "name":  "MultiSelect",
+                      "description":  "Selects multiple items such as files, folders, or checkboxes if press_ctrl=True, or performs multiple clicks if False. Pass locs (list of coordinates) or labels (list of UI element labels/ids)."
+                  },
+                  {
+                      "name":  "MultiEdit",
+                      "description":  "Enters text into multiple input fields at specified coordinates locs=[[x,y,text], ...] or using labels=[[label,text], ...]. Provide either locs or labels."
+                  },
+                  {
+                      "name":  "Clipboard",
+                      "description":  "Manages Windows clipboard operations. Use mode=\"get\" to read current clipboard content, mode=\"set\" to set clipboard text."
+                  },
+                  {
+                      "name":  "Process",
+                      "description":  "Manages system processes. Use mode=\"list\" to list running processes with filtering and sorting options. Use mode=\"kill\" to terminate processes by PID or name."
+                  },
+                  {
+                      "name":  "Notification",
+                      "description":  "Sends a Windows toast notification with a title and message. Useful for alerting the user remotely."
+                  },
+                  {
+                      "name":  "Registry",
+                      "description":  "Accesses the Windows Registry. Use mode=\"get\" to read a value, mode=\"set\" to create/update a value, mode=\"delete\" to remove a value or key, mode=\"list\" to list values and sub-keys under a path."
+                  }
+              ],
+    "compatibility":  {
+                          "platforms":  [
+                                            "win32"
+                                        ],
+                          "runtimes":  {
+                                           "python":  "\u003e=3.13"
+                                       }
+                      },
+    "keywords":  [
+                     "windows",
+                     "automation",
+                     "ai",
+                     "mcp",
+                     "computer-use"
+                 ],
+    "license":  "MIT",
+    "repository":  {
+                       "type":  "git",
+                       "url":  "https://github.com/CursorTouch/Windows-MCP"
+                   }
 }


### PR DESCRIPTION
## Summary

On corporate Windows machines, security policies like **AppLocker** and **Software Restriction Policies** block execution of binaries from user profile directories (`%APPDATA%`, `%LOCALAPPDATA%`). Since UV stores its cache, managed Python interpreters, and virtual environments under these paths by default, Windows-MCP **fails to start entirely** on locked-down machines.

This PR adds three optional `user_config` entries to `manifest.json` that let users redirect UV's storage directories to an unrestricted path (e.g., `C:/dev/.uv/`).

## Changes

### `manifest.json`
- Added three environment variables to `server.mcp_config.env`: `UV_CACHE_DIR`, `UV_PYTHON_INSTALL_DIR`, `UV_PROJECT_ENVIRONMENT`
- Added three corresponding `user_config` entries with descriptive titles and descriptions that explain *why* they exist (AppLocker) and link to UV's official docs

### `README.md`
- Added a **Corporate / Restricted Environments** section explaining the symptom, cause, and fix with example config

## Design Decisions

- **`required: false` with no default** — When unset, UV uses its built-in platform-specific defaults. Zero impact on users without restricted environments.
- **Environment variables (not `uv.toml`)** — `uv.toml` would require modifying repo-tracked files as a user-specific override. Env vars take precedence in UV's resolution order and fit naturally into the MCP manifest's `env` block.
- **No single `UV_HOME` shortcut** — UV does not have one. The three directories serve different purposes with independent default locations by design.

## UV Documentation References

- [`UV_CACHE_DIR`](https://docs.astral.sh/uv/reference/environment/#uv_cache_dir)
- [`UV_PYTHON_INSTALL_DIR`](https://docs.astral.sh/uv/reference/environment/#uv_python_install_dir)
- [`UV_PROJECT_ENVIRONMENT`](https://docs.astral.sh/uv/reference/environment/#uv_project_environment)

## Testing

| Scenario | Expected result |
|---|---|
| All three vars unset (default) | UV uses built-in defaults, no behavior change |
| All three set to valid writable paths | UV stores artifacts at custom paths, server starts |
| Restricted env + vars unset | Fails (existing behavior, unchanged) |
| Restricted env + vars set | Server starts successfully |

## Prompt for Reproducing These Changes

If you prefer to recreate these changes yourself with an AI coding tool, here is a self-contained prompt:

<details>
<summary>Click to expand the reproduction prompt</summary>

### Context

I maintain the Windows-MCP project — an MCP server that lets AI agents interact with Windows OS. The server is launched via the `uv` package manager (by Astral), and its configuration lives in `manifest.json` at the repo root.

### Problem

On corporate Windows machines, security policies like **AppLocker** and **Software Restriction Policies** block execution of binaries from user profile directories (`%APPDATA%`, `%LOCALAPPDATA%`). By default, `uv` stores three categories of files in these locations:

1. **Package cache** (downloaded wheels, build artifacts) — `%LOCALAPPDATA%/uv/cache`
2. **Managed Python interpreters** — `%APPDATA%/uv/python`
3. **Project virtual environment** — `.venv` in the project root (which may itself be under a user profile path)

This means Windows-MCP **fails to start entirely** on locked-down machines because `uv` can't run the Python it installs or access its own cache.

### What I need you to do

Edit **only** `manifest.json` to add three optional user-configurable environment variables that let users redirect these UV storage directories to unrestricted paths. The three official UV environment variables are:

- `UV_CACHE_DIR` — see https://docs.astral.sh/uv/reference/environment/#uv_cache_dir
- `UV_PYTHON_INSTALL_DIR` — see https://docs.astral.sh/uv/reference/environment/#uv_python_install_dir
- `UV_PROJECT_ENVIRONMENT` — see https://docs.astral.sh/uv/reference/environment/#uv_project_environment

### Specific changes in `manifest.json`

**1. In `server.mcp_config.env`**, add these three entries after the existing `WINDOWS_MCP_DEBUG` line:

```
"UV_CACHE_DIR": "${user_config.uv_cache_dir}",
"UV_PYTHON_INSTALL_DIR": "${user_config.uv_python_install_dir}",
"UV_PROJECT_ENVIRONMENT": "${user_config.uv_project_environment}"
```

Don't forget to add a trailing comma to the `WINDOWS_MCP_DEBUG` line above.

**2. In `user_config`**, add these three entries after the existing `debug` entry:

```json
"uv_cache_dir": {
  "type": "string",
  "title": "UV Cache Directory",
  "description": "Override where UV stores downloaded packages and build artifacts. Useful when system policies (e.g., AppLocker) block running executables from the user profile directory. Leave empty to use UV's default. Docs: https://docs.astral.sh/uv/reference/environment/#uv_cache_dir",
  "required": false
},
"uv_python_install_dir": {
  "type": "string",
  "title": "UV Python Install Directory",
  "description": "Override where UV installs managed Python interpreters. Useful when system policies block running executables from the user profile directory. Leave empty to use UV's default. Docs: https://docs.astral.sh/uv/reference/environment/#uv_python_install_dir",
  "required": false
},
"uv_project_environment": {
  "type": "string",
  "title": "UV Project Virtual Environment",
  "description": "Override where UV creates this project's virtual environment instead of the default .venv directory. Useful when system policies block running executables from the user profile directory. Leave empty to use UV's default. Docs: https://docs.astral.sh/uv/reference/environment/#uv_project_environment",
  "required": false
}
```

### Design constraints

- All three must be `required: false` with **no default value**. When unset, UV uses its built-in platform-specific defaults, so there's zero impact on users without restrictions.
- Config key names should match UV's own naming: `uv_cache_dir`, `uv_python_install_dir`, `uv_project_environment` (not abbreviated or renamed).
- Descriptions should explain the *why* (system policies blocking profile directory executables), not just the *what*, and link to the relevant UV docs page.
- Don't forget the trailing comma on the JSON line preceding each new entry. Validate that the resulting `manifest.json` is valid JSON.

### Also update `README.md`

Add a section called **"Corporate / Restricted Environments"** (or similar) near the installation instructions. It should explain:

- **The symptom**: Windows-MCP fails to start with errors about blocked executables or permission denied.
- **The cause**: System policies (AppLocker, SRP) blocking execution from `%APPDATA%` / `%LOCALAPPDATA%`.
- **The fix**: Set the three UV path override settings in your MCP client configuration to point to a writable, unrestricted directory.
- **Example values**: `C:/dev/.uv/cache`, `C:/dev/.uv/python`, `C:/dev/.uv/venvs/windows-mcp`.

### Validation

After making the changes, verify:
1. `manifest.json` is valid JSON (run `python -m json.tool manifest.json`).
2. No existing env vars or user_config entries were modified or removed.
3. The three new env var keys in `server.mcp_config.env` map correctly to their `user_config` counterparts via `${user_config.<key>}` syntax.

</details>
