### PR TITLE
feat: add UV path override config for restricted Windows environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,39 @@ npm install -g @anthropic-ai/claude-code
 
 ---
 
+
+### Corporate / Restricted Environments
+
+On locked-down Windows machines, security policies such as **AppLocker** or **Software Restriction Policies** may block execution of binaries from user-profile directories (`%APPDATA%`, `%LOCALAPPDATA%`). Since UV stores its cache, managed Python interpreters, and virtual environments under these paths by default, Windows-MCP will fail to start.
+
+To work around this, configure the three UV path overrides in your MCP client settings to point to a directory outside the user profile (e.g., `C:\dev\.uv`):
+
+| Setting | Example value | UV docs |
+|---|---|---|
+| `uv_cache_dir` | `C:/dev/.uv/cache` | [UV_CACHE_DIR](https://docs.astral.sh/uv/reference/environment/#uv_cache_dir) |
+| `uv_python_install_dir` | `C:/dev/.uv/python` | [UV_PYTHON_INSTALL_DIR](https://docs.astral.sh/uv/reference/environment/#uv_python_install_dir) |
+| `uv_project_environment` | `C:/dev/.uv/venvs/windows-mcp` | [UV_PROJECT_ENVIRONMENT](https://docs.astral.sh/uv/reference/environment/#uv_project_environment) |
+
+If you are configuring Windows-MCP manually via `claude_desktop_config.json` (or equivalent), add these as environment variables:
+
+```json
+{
+  "mcpServers": {
+    "windows-mcp": {
+      "command": "uvx",
+      "args": ["windows-mcp"],
+      "env": {
+        "UV_CACHE_DIR": "C:/dev/.uv/cache",
+        "UV_PYTHON_INSTALL_DIR": "C:/dev/.uv/python",
+        "UV_PROJECT_ENVIRONMENT": "C:/dev/.uv/venvs/windows-mcp"
+      }
+    }
+  }
+}
+```
+
+The target directories must exist and be writable. These settings have no effect when left unset; UV will use its built-in defaults.
+
 ## 🖥️ Modes
 
 Windows-MCP supports two operating modes: **Local** (default) and **Remote**.

--- a/manifest.json
+++ b/manifest.json
@@ -34,7 +34,10 @@
         "API_KEY": "${user_config.api_key}",
         "WINDOWS_MCP_PROFILE_SNAPSHOT": "${user_config.profile_snapshot}",
         "WINDOWS_MCP_SCREENSHOT_BACKEND": "${user_config.screenshot_backend}",
-        "WINDOWS_MCP_DEBUG": "${user_config.debug}"
+        "WINDOWS_MCP_DEBUG": "${user_config.debug}",
+        "UV_CACHE_DIR": "${user_config.uv_cache_dir}",
+        "UV_PYTHON_INSTALL_DIR": "${user_config.uv_python_install_dir}",
+        "UV_PROJECT_ENVIRONMENT": "${user_config.uv_project_environment}"
       }
     }
   },
@@ -85,6 +88,24 @@
       "description": "Enable debug mode to provide verbose logging for troubleshooting.",
       "required": false,
       "default": false
+    },
+    "uv_cache_dir": {
+      "type": "string",
+      "title": "UV Cache Directory",
+      "description": "Override where UV stores downloaded packages and build artifacts. Useful when system policies (e.g., AppLocker) block running executables from the user profile directory. Leave unset to use UV's default. Docs: https://docs.astral.sh/uv/reference/environment/#uv_cache_dir",
+      "required": false
+    },
+    "uv_python_install_dir": {
+      "type": "string",
+      "title": "UV Python Install Directory",
+      "description": "Override where UV installs managed Python interpreters. Useful when system policies block running executables from the user profile directory. Leave unset to use UV's default. Docs: https://docs.astral.sh/uv/reference/environment/#uv_python_install_dir",
+      "required": false
+    },
+    "uv_project_environment": {
+      "type": "string",
+      "title": "UV Project Virtual Environment",
+      "description": "Override where UV creates this project's virtual environment instead of the default .venv directory. Useful when system policies block running executables from the user profile directory. Leave unset to use UV's default. Docs: https://docs.astral.sh/uv/reference/environment/#uv_project_environment",
+      "required": false
     }
   },
   "tools": [


### PR DESCRIPTION
## Summary

On corporate Windows machines, security policies like **AppLocker** and **Software Restriction Policies** block execution of binaries from user profile directories (`%APPDATA%`, `%LOCALAPPDATA%`). Since UV stores its cache, managed Python interpreters, and virtual environments under these paths by default, Windows-MCP **fails to start entirely** on locked-down machines.

This PR adds three optional `user_config` entries to `manifest.json` that let users redirect UV's storage directories to an unrestricted path (e.g., `C:/dev/.uv/`).

## Changes

### `manifest.json`
- Added three environment variables to `server.mcp_config.env`: `UV_CACHE_DIR`, `UV_PYTHON_INSTALL_DIR`, `UV_PROJECT_ENVIRONMENT`
- Added three corresponding `user_config` entries with descriptive titles and descriptions that explain *why* they exist (AppLocker) and link to UV's official docs

### `README.md`
- Added a **Corporate / Restricted Environments** section explaining the symptom, cause, and fix with example config

## Design Decisions

- **`required: false` with no default** â€” When unset, UV uses its built-in platform-specific defaults. Zero impact on users without restricted environments.
- **Environment variables (not `uv.toml`)** â€” `uv.toml` would require modifying repo-tracked files as a user-specific override. Env vars take precedence in UV's resolution order and fit naturally into the MCP manifest's `env` block.
- **No single `UV_HOME` shortcut** â€” UV does not have one. The three directories serve different purposes with independent default locations by design.

## UV Documentation References

- [`UV_CACHE_DIR`](https://docs.astral.sh/uv/reference/environment/#uv_cache_dir)
- [`UV_PYTHON_INSTALL_DIR`](https://docs.astral.sh/uv/reference/environment/#uv_python_install_dir)
- [`UV_PROJECT_ENVIRONMENT`](https://docs.astral.sh/uv/reference/environment/#uv_project_environment)

## Testing

| Scenario | Expected result |
|---|---|
| All three vars unset (default) | UV uses built-in defaults, no behavior change |
| All three set to valid writable paths | UV stores artifacts at custom paths, server starts |
| Restricted env + vars unset | Fails (existing behavior, unchanged) |
| Restricted env + vars set | Server starts successfully |

## Prompt for Reproducing These Changes

If you prefer to recreate these changes yourself with an AI coding tool, here is a self-contained prompt:

<details>
<summary>Click to expand the reproduction prompt</summary>

### Context

I maintain the Windows-MCP project â€” an MCP server that lets AI agents interact with Windows OS. The server is launched via the `uv` package manager (by Astral), and its configuration lives in `manifest.json` at the repo root.

### Problem

On corporate Windows machines, security policies like **AppLocker** and **Software Restriction Policies** block execution of binaries from user profile directories (`%APPDATA%`, `%LOCALAPPDATA%`). By default, `uv` stores three categories of files in these locations:

1. **Package cache** (downloaded wheels, build artifacts) â€” `%LOCALAPPDATA%/uv/cache`
2. **Managed Python interpreters** â€” `%APPDATA%/uv/python`
3. **Project virtual environment** â€” `.venv` in the project root (which may itself be under a user profile path)

This means Windows-MCP **fails to start entirely** on locked-down machines because `uv` can't run the Python it installs or access its own cache.

### What I need you to do

Edit **only** `manifest.json` to add three optional user-configurable environment variables that let users redirect these UV storage directories to unrestricted paths. The three official UV environment variables are:

- `UV_CACHE_DIR` â€” see https://docs.astral.sh/uv/reference/environment/#uv_cache_dir
- `UV_PYTHON_INSTALL_DIR` â€” see https://docs.astral.sh/uv/reference/environment/#uv_python_install_dir
- `UV_PROJECT_ENVIRONMENT` â€” see https://docs.astral.sh/uv/reference/environment/#uv_project_environment

### Specific changes in `manifest.json`

**1. In `server.mcp_config.env`**, add these three entries after the existing `WINDOWS_MCP_DEBUG` line:

```
"UV_CACHE_DIR": "${user_config.uv_cache_dir}",
"UV_PYTHON_INSTALL_DIR": "${user_config.uv_python_install_dir}",
"UV_PROJECT_ENVIRONMENT": "${user_config.uv_project_environment}"
```

Don't forget to add a trailing comma to the `WINDOWS_MCP_DEBUG` line above.

**2. In `user_config`**, add these three entries after the existing `debug` entry:

```json
"uv_cache_dir": {
  "type": "string",
  "title": "UV Cache Directory",
  "description": "Override where UV stores downloaded packages and build artifacts. Useful when system policies (e.g., AppLocker) block running executables from the user profile directory. Leave empty to use UV's default. Docs: https://docs.astral.sh/uv/reference/environment/#uv_cache_dir",
  "required": false
},
"uv_python_install_dir": {
  "type": "string",
  "title": "UV Python Install Directory",
  "description": "Override where UV installs managed Python interpreters. Useful when system policies block running executables from the user profile directory. Leave empty to use UV's default. Docs: https://docs.astral.sh/uv/reference/environment/#uv_python_install_dir",
  "required": false
},
"uv_project_environment": {
  "type": "string",
  "title": "UV Project Virtual Environment",
  "description": "Override where UV creates this project's virtual environment instead of the default .venv directory. Useful when system policies block running executables from the user profile directory. Leave empty to use UV's default. Docs: https://docs.astral.sh/uv/reference/environment/#uv_project_environment",
  "required": false
}
```

### Design constraints

- All three must be `required: false` with **no default value**. When unset, UV uses its built-in platform-specific defaults, so there's zero impact on users without restrictions.
- Config key names should match UV's own naming: `uv_cache_dir`, `uv_python_install_dir`, `uv_project_environment` (not abbreviated or renamed).
- Descriptions should explain the *why* (system policies blocking profile directory executables), not just the *what*, and link to the relevant UV docs page.
- Don't forget the trailing comma on the JSON line preceding each new entry. Validate that the resulting `manifest.json` is valid JSON.

### Also update `README.md`

Add a section called **"Corporate / Restricted Environments"** (or similar) near the installation instructions. It should explain:

- **The symptom**: Windows-MCP fails to start with errors about blocked executables or permission denied.
- **The cause**: System policies (AppLocker, SRP) blocking execution from `%APPDATA%` / `%LOCALAPPDATA%`.
- **The fix**: Set the three UV path override settings in your MCP client configuration to point to a writable, unrestricted directory.
- **Example values**: `C:/dev/.uv/cache`, `C:/dev/.uv/python`, `C:/dev/.uv/venvs/windows-mcp`.

### Validation

After making the changes, verify:
1. `manifest.json` is valid JSON (run `python -m json.tool manifest.json`).
2. No existing env vars or user_config entries were modified or removed.
3. The three new env var keys in `server.mcp_config.env` map correctly to their `user_config` counterparts via `${user_config.<key>}` syntax.

</details>
