### PR TITLE
Refactor screenshot capture module for cohesion and extensibility

### DIFF
--- a/src/windows_mcp/desktop/screenshot.py
+++ b/src/windows_mcp/desktop/screenshot.py
@@ -14,8 +14,30 @@ try:
 except ImportError:
     mss = None
 
+import windows_mcp.uia as uia
 
 logger = logging.getLogger(__name__)
+
+
+def _build_crop_box(capture_rect: uia.Rect, padding: int = 0) -> tuple[int, int, int, int]:
+    left_offset, top_offset, _, _ = uia.GetVirtualScreenRect()
+    return (
+        capture_rect.left - left_offset + padding,
+        capture_rect.top - top_offset + padding,
+        capture_rect.right - left_offset + padding,
+        capture_rect.bottom - top_offset + padding,
+    )
+
+
+def _crop_screenshot(
+        screenshot: Image.Image, capture_rect: uia.Rect | None
+) -> Image.Image:
+    if capture_rect is None:
+        return screenshot
+    return screenshot.crop(_build_crop_box(capture_rect))
+
+
+_DXCAM_CAMERA_CACHE: dict[int, object] = {}
 
 
 def get_screenshot_backend() -> str:
@@ -31,8 +53,8 @@ def get_screenshot_backend() -> str:
 
 
 def resolve_dxcam_region(
-    capture_rect,
-    get_monitors_rect: Callable[[], list],
+        capture_rect,
+        get_monitors_rect: Callable[[], list],
 ) -> tuple[int, tuple[int, int, int, int] | None] | None:
     if capture_rect is None:
         return 0, None
@@ -40,10 +62,10 @@ def resolve_dxcam_region(
     monitor_rects = get_monitors_rect()
     for output_idx, monitor_rect in enumerate(monitor_rects):
         if (
-            monitor_rect.left <= capture_rect.left
-            and monitor_rect.top <= capture_rect.top
-            and monitor_rect.right >= capture_rect.right
-            and monitor_rect.bottom >= capture_rect.bottom
+                monitor_rect.left <= capture_rect.left
+                and monitor_rect.top <= capture_rect.top
+                and monitor_rect.right >= capture_rect.right
+                and monitor_rect.bottom >= capture_rect.bottom
         ):
             if monitor_rect == capture_rect:
                 return output_idx, None
@@ -56,37 +78,36 @@ def resolve_dxcam_region(
     return None
 
 
-def get_dxcam_camera(output_idx: int, camera_cache: dict[int, object], dxcam_module=None):
-    module = dxcam_module if dxcam_module is not None else dxcam
-    if module is None:
+def get_dxcam_camera(output_idx: int):
+    global _DXCAM_CAMERA_CACHE
+
+    if dxcam is None:
         raise RuntimeError("dxcam is not available")
 
-    camera = camera_cache.get(output_idx)
+    camera = _DXCAM_CAMERA_CACHE.get(output_idx)
     if camera is None:
-        camera = module.create(output_idx=output_idx, processor_backend="numpy")
-        camera_cache[output_idx] = camera
+        camera = dxcam.create(output_idx=output_idx, processor_backend="numpy")
+        _DXCAM_CAMERA_CACHE[output_idx] = camera
     return camera
 
 
 def capture_with_dxcam(
-    capture_rect,
-    get_monitors_rect: Callable[[], list],
-    camera_cache: dict[int, object],
-    dxcam_module=None,
+        capture_rect,
+        get_monitors_rect: Callable[[], list],
 ) -> Image.Image:
     resolved = resolve_dxcam_region(capture_rect, get_monitors_rect)
     if resolved is None:
         raise ValueError("DXGI capture supports only regions fully contained within one display")
 
     output_idx, region = resolved
-    camera = get_dxcam_camera(output_idx, camera_cache, dxcam_module=dxcam_module)
+    camera = get_dxcam_camera(output_idx)
     frame = camera.grab(region=region, copy=True, new_frame_only=False)
     if frame is None:
         raise RuntimeError("DXGI capture returned no frame")
     return Image.fromarray(frame)
 
 
-def capture_with_pillow(capture_rect, crop_screenshot: Callable[[Image.Image, object], Image.Image]) -> Image.Image:
+def capture_with_pillow(capture_rect) -> Image.Image:
     grab_kwargs = {"all_screens": True}
     if capture_rect is not None:
         grab_kwargs["bbox"] = (
@@ -102,18 +123,17 @@ def capture_with_pillow(capture_rect, crop_screenshot: Callable[[Image.Image, ob
             logger.warning(
                 "Failed to capture selected region directly, falling back to virtual screen crop"
             )
-            return crop_screenshot(ImageGrab.grab(all_screens=True), capture_rect)
+            return _crop_screenshot(ImageGrab.grab(all_screens=True), capture_rect)
         logger.warning("Failed to capture virtual screen, using primary screen")
         screenshot = ImageGrab.grab()
-    return crop_screenshot(screenshot, capture_rect)
+    return _crop_screenshot(screenshot, capture_rect)
 
 
-def capture_with_mss(capture_rect, crop_screenshot: Callable[[Image.Image, object], Image.Image], mss_module=None) -> Image.Image:
-    module = mss_module if mss_module is not None else mss
-    if module is None:
+def capture_with_mss(capture_rect) -> Image.Image:
+    if mss is None:
         raise RuntimeError("mss is not available")
 
-    with module.mss() as sct:
+    with mss.mss() as sct:
         if capture_rect is None:
             monitor = sct.monitors[0]
         else:
@@ -125,7 +145,7 @@ def capture_with_mss(capture_rect, crop_screenshot: Callable[[Image.Image, objec
             }
         raw = sct.grab(monitor)
         image = Image.frombytes("RGB", raw.size, raw.rgb)
-    return crop_screenshot(image, capture_rect)
+    return _crop_screenshot(image, capture_rect)
 
 
 def _auto_backend_chain() -> list[str]:
@@ -133,13 +153,9 @@ def _auto_backend_chain() -> list[str]:
 
 
 def capture(
-    capture_rect,
-    crop_screenshot: Callable[[Image.Image, object], Image.Image],
-    get_monitors_rect: Callable[[], list],
-    camera_cache: dict[int, object],
-    backend: str | None = None,
-    dxcam_module=None,
-    mss_module=None,
+        capture_rect,
+        get_monitors_rect: Callable[[], list],
+        backend: str | None = None,
 ) -> tuple[Image.Image, str]:
     selected = backend or get_screenshot_backend()
     chain = _auto_backend_chain() if selected == "auto" else [selected]
@@ -149,28 +165,26 @@ def capture(
             if backend_name == "dxcam":
                 if capture_rect is None:
                     continue
-                if (dxcam_module if dxcam_module is not None else dxcam) is None:
+                if dxcam is None:
                     continue
                 return (
                     capture_with_dxcam(
                         capture_rect,
                         get_monitors_rect,
-                        camera_cache,
-                        dxcam_module=dxcam_module,
                     ),
                     "dxcam",
                 )
 
             if backend_name == "mss":
-                if (mss_module if mss_module is not None else mss) is None:
+                if mss is None:
                     continue
                 return (
-                    capture_with_mss(capture_rect, crop_screenshot, mss_module=mss_module),
+                    capture_with_mss(capture_rect),
                     "mss",
                 )
 
             if backend_name == "pillow":
-                return (capture_with_pillow(capture_rect, crop_screenshot), "pillow")
+                return capture_with_pillow(capture_rect), "pillow"
 
         except (OSError, RuntimeError, ValueError):
             logger.warning(
@@ -180,4 +194,5 @@ def capture(
             )
 
     # Final safety fallback so capture always returns an image on supported hosts.
-    return (capture_with_pillow(capture_rect, crop_screenshot), "pillow")
+    return capture_with_pillow(capture_rect), "pillow"
+

--- a/src/windows_mcp/desktop/screenshot.py
+++ b/src/windows_mcp/desktop/screenshot.py
@@ -1,6 +1,5 @@
 import logging
 import os
-from typing import Callable
 
 from PIL import Image, ImageGrab
 
@@ -52,14 +51,11 @@ def get_screenshot_backend() -> str:
     return "auto"
 
 
-def resolve_dxcam_region(
-        capture_rect,
-        get_monitors_rect: Callable[[], list],
-) -> tuple[int, tuple[int, int, int, int] | None] | None:
+def resolve_dxcam_region(capture_rect) -> tuple[int, tuple[int, int, int, int] | None] | None:
     if capture_rect is None:
         return 0, None
 
-    monitor_rects = get_monitors_rect()
+    monitor_rects = uia.GetMonitorsRect()
     for output_idx, monitor_rect in enumerate(monitor_rects):
         if (
                 monitor_rect.left <= capture_rect.left
@@ -91,11 +87,8 @@ def get_dxcam_camera(output_idx: int):
     return camera
 
 
-def capture_with_dxcam(
-        capture_rect,
-        get_monitors_rect: Callable[[], list],
-) -> Image.Image:
-    resolved = resolve_dxcam_region(capture_rect, get_monitors_rect)
+def capture_with_dxcam(capture_rect) -> Image.Image:
+    resolved = resolve_dxcam_region(capture_rect)
     if resolved is None:
         raise ValueError("DXGI capture supports only regions fully contained within one display")
 
@@ -152,11 +145,7 @@ def _auto_backend_chain() -> list[str]:
     return ["dxcam", "mss", "pillow"]
 
 
-def capture(
-        capture_rect,
-        get_monitors_rect: Callable[[], list],
-        backend: str | None = None,
-) -> tuple[Image.Image, str]:
+def capture(capture_rect, backend: str | None = None) -> tuple[Image.Image, str]:
     selected = backend or get_screenshot_backend()
     chain = _auto_backend_chain() if selected == "auto" else [selected]
 
@@ -167,21 +156,12 @@ def capture(
                     continue
                 if dxcam is None:
                     continue
-                return (
-                    capture_with_dxcam(
-                        capture_rect,
-                        get_monitors_rect,
-                    ),
-                    "dxcam",
-                )
+                return capture_with_dxcam(capture_rect), "dxcam"
 
             if backend_name == "mss":
                 if mss is None:
                     continue
-                return (
-                    capture_with_mss(capture_rect),
-                    "mss",
-                )
+                return capture_with_mss(capture_rect), "mss"
 
             if backend_name == "pillow":
                 return capture_with_pillow(capture_rect), "pillow"

--- a/src/windows_mcp/desktop/screenshot.py
+++ b/src/windows_mcp/desktop/screenshot.py
@@ -18,6 +18,11 @@ import windows_mcp.uia as uia
 logger = logging.getLogger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# Shared utilities
+# ---------------------------------------------------------------------------
+
+
 def _build_crop_box(capture_rect: uia.Rect, padding: int = 0) -> tuple[int, int, int, int]:
     left_offset, top_offset, _, _ = uia.GetVirtualScreenRect()
     return (
@@ -28,21 +33,18 @@ def _build_crop_box(capture_rect: uia.Rect, padding: int = 0) -> tuple[int, int,
     )
 
 
-def _crop_screenshot(
-        screenshot: Image.Image, capture_rect: uia.Rect | None
-) -> Image.Image:
+def _crop_screenshot(screenshot: Image.Image, capture_rect: uia.Rect | None) -> Image.Image:
     if capture_rect is None:
         return screenshot
     return screenshot.crop(_build_crop_box(capture_rect))
 
 
-_DXCAM_CAMERA_CACHE: dict[int, object] = {}
-
-
 def get_screenshot_backend() -> str:
+    """Read the preferred backend from the environment variable."""
     value = os.getenv("WINDOWS_MCP_SCREENSHOT_BACKEND", "auto")
     normalized = value.strip().lower()
-    if normalized in {"auto", "pillow", "dxcam", "mss"}:
+    valid = _ScreenshotBackend.registry.keys() | {"auto"}
+    if normalized in valid:
         return normalized
     logger.warning(
         "Unknown screenshot backend '%s'; falling back to auto",
@@ -51,128 +53,209 @@ def get_screenshot_backend() -> str:
     return "auto"
 
 
-def resolve_dxcam_region(capture_rect) -> tuple[int, tuple[int, int, int, int] | None] | None:
-    if capture_rect is None:
-        return 0, None
+# ---------------------------------------------------------------------------
+# Backend framework
+# ---------------------------------------------------------------------------
 
-    monitor_rects = uia.GetMonitorsRect()
-    for output_idx, monitor_rect in enumerate(monitor_rects):
-        if (
+
+class _ScreenshotBackend:
+    """Base class for screenshot capture backends.
+
+    Subclasses **must** define two class attributes:
+
+    * ``name: str`` – unique key such as ``"dxcam"``.
+    * ``priority: int`` – lower numbers are tried first in the *auto* chain.
+
+    Defining both attributes automatically registers the subclass via
+    ``__init_subclass__``.
+    """
+
+    name: str
+    priority: int
+
+    registry: dict[str, type["_ScreenshotBackend"]] = {}
+
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        super().__init_subclass__(**kwargs)
+        if hasattr(cls, "name") and hasattr(cls, "priority"):
+            _ScreenshotBackend.registry[cls.name] = cls
+
+    def is_available(self, capture_rect: uia.Rect | None) -> bool:
+        """Return ``True`` if this backend can service the request."""
+        return True
+
+    def capture(self, capture_rect: uia.Rect | None) -> Image.Image:
+        """Capture a screenshot.  Subclasses must override."""
+        raise NotImplementedError
+
+
+class _DxcamBackend(_ScreenshotBackend):
+    """DXGI-based capture via the *dxcam* library."""
+
+    name = "dxcam"
+    priority = 10
+
+    def __init__(self) -> None:
+        self._camera_cache: dict[int, object] = {}
+
+    @staticmethod
+    def _resolve_region(
+        capture_rect: uia.Rect,
+    ) -> tuple[int, tuple[int, int, int, int] | None] | None:
+        """Return ``(output_idx, region)`` if *capture_rect* fits one monitor, else ``None``."""
+        monitor_rects = uia.GetMonitorsRect()
+        for output_idx, monitor_rect in enumerate(monitor_rects):
+            if (
                 monitor_rect.left <= capture_rect.left
                 and monitor_rect.top <= capture_rect.top
                 and monitor_rect.right >= capture_rect.right
                 and monitor_rect.bottom >= capture_rect.bottom
-        ):
-            if monitor_rect == capture_rect:
-                return output_idx, None
-            return output_idx, (
-                capture_rect.left - monitor_rect.left,
-                capture_rect.top - monitor_rect.top,
-                capture_rect.right - monitor_rect.left,
-                capture_rect.bottom - monitor_rect.top,
-            )
-    return None
+            ):
+                if monitor_rect == capture_rect:
+                    return output_idx, None
+                return output_idx, (
+                    capture_rect.left - monitor_rect.left,
+                    capture_rect.top - monitor_rect.top,
+                    capture_rect.right - monitor_rect.left,
+                    capture_rect.bottom - monitor_rect.top,
+                )
+        return None
 
-
-def get_dxcam_camera(output_idx: int):
-    global _DXCAM_CAMERA_CACHE
-
-    if dxcam is None:
-        raise RuntimeError("dxcam is not available")
-
-    camera = _DXCAM_CAMERA_CACHE.get(output_idx)
-    if camera is None:
-        camera = dxcam.create(output_idx=output_idx, processor_backend="numpy")
-        _DXCAM_CAMERA_CACHE[output_idx] = camera
-    return camera
-
-
-def capture_with_dxcam(capture_rect) -> Image.Image:
-    resolved = resolve_dxcam_region(capture_rect)
-    if resolved is None:
-        raise ValueError("DXGI capture supports only regions fully contained within one display")
-
-    output_idx, region = resolved
-    camera = get_dxcam_camera(output_idx)
-    frame = camera.grab(region=region, copy=True, new_frame_only=False)
-    if frame is None:
-        raise RuntimeError("DXGI capture returned no frame")
-    return Image.fromarray(frame)
-
-
-def capture_with_pillow(capture_rect) -> Image.Image:
-    grab_kwargs = {"all_screens": True}
-    if capture_rect is not None:
-        grab_kwargs["bbox"] = (
-            capture_rect.left,
-            capture_rect.top,
-            capture_rect.right,
-            capture_rect.bottom,
-        )
-    try:
-        screenshot = ImageGrab.grab(**grab_kwargs)
-    except (OSError, RuntimeError, ValueError):
-        if capture_rect is not None:
-            logger.warning(
-                "Failed to capture selected region directly, falling back to virtual screen crop"
-            )
-            return _crop_screenshot(ImageGrab.grab(all_screens=True), capture_rect)
-        logger.warning("Failed to capture virtual screen, using primary screen")
-        screenshot = ImageGrab.grab()
-    return _crop_screenshot(screenshot, capture_rect)
-
-
-def capture_with_mss(capture_rect) -> Image.Image:
-    if mss is None:
-        raise RuntimeError("mss is not available")
-
-    with mss.mss() as sct:
+    def is_available(self, capture_rect: uia.Rect | None) -> bool:
+        if dxcam is None:
+            return False
         if capture_rect is None:
-            monitor = sct.monitors[0]
-        else:
-            monitor = {
-                "left": capture_rect.left,
-                "top": capture_rect.top,
-                "width": capture_rect.right - capture_rect.left,
-                "height": capture_rect.bottom - capture_rect.top,
-            }
-        raw = sct.grab(monitor)
-        image = Image.frombytes("RGB", raw.size, raw.rgb)
-    return _crop_screenshot(image, capture_rect)
+            return False
+        return self._resolve_region(capture_rect) is not None
+
+    def _get_camera(self, output_idx: int) -> object:
+        camera = self._camera_cache.get(output_idx)
+        if camera is None:
+            camera = dxcam.create(output_idx=output_idx, processor_backend="numpy")
+            self._camera_cache[output_idx] = camera
+        return camera
+
+    def capture(self, capture_rect: uia.Rect | None) -> Image.Image:
+        resolved = self._resolve_region(capture_rect)
+        if resolved is None:
+            raise ValueError(
+                "DXGI capture supports only regions fully contained within one display"
+            )
+        output_idx, region = resolved
+        camera = self._get_camera(output_idx)
+        frame = camera.grab(region=region, copy=True, new_frame_only=False)
+        if frame is None:
+            raise RuntimeError("DXGI capture returned no frame")
+        return Image.fromarray(frame)
 
 
-def _auto_backend_chain() -> list[str]:
-    return ["dxcam", "mss", "pillow"]
+class _PillowBackend(_ScreenshotBackend):
+    """Capture via PIL *ImageGrab* (always available)."""
 
+    name = "pillow"
+    priority = 100
 
-def capture(capture_rect, backend: str | None = None) -> tuple[Image.Image, str]:
-    selected = backend or get_screenshot_backend()
-    chain = _auto_backend_chain() if selected == "auto" else [selected]
-
-    for backend_name in chain:
+    def capture(self, capture_rect: uia.Rect | None) -> Image.Image:
+        grab_kwargs: dict[str, object] = {"all_screens": True}
+        if capture_rect is not None:
+            grab_kwargs["bbox"] = (
+                capture_rect.left,
+                capture_rect.top,
+                capture_rect.right,
+                capture_rect.bottom,
+            )
         try:
-            if backend_name == "dxcam":
-                if capture_rect is None:
-                    continue
-                if dxcam is None:
-                    continue
-                return capture_with_dxcam(capture_rect), "dxcam"
+            screenshot = ImageGrab.grab(**grab_kwargs)
+        except (OSError, RuntimeError, ValueError):
+            if capture_rect is not None:
+                logger.warning(
+                    "Failed to capture selected region directly, "
+                    "falling back to virtual screen crop"
+                )
+                return _crop_screenshot(ImageGrab.grab(all_screens=True), capture_rect)
+            logger.warning("Failed to capture virtual screen, using primary screen")
+            screenshot = ImageGrab.grab()
+        return _crop_screenshot(screenshot, capture_rect)
 
-            if backend_name == "mss":
-                if mss is None:
-                    continue
-                return capture_with_mss(capture_rect), "mss"
 
-            if backend_name == "pillow":
-                return capture_with_pillow(capture_rect), "pillow"
+class _MssBackend(_ScreenshotBackend):
+    """Capture via the *mss* library."""
 
+    name = "mss"
+    priority = 20
+
+    def is_available(self, capture_rect: uia.Rect | None) -> bool:
+        return mss is not None
+
+    def capture(self, capture_rect: uia.Rect | None) -> Image.Image:
+        if mss is None:
+            raise RuntimeError("mss is not available")
+        with mss.mss() as sct:
+            if capture_rect is None:
+                monitor = sct.monitors[0]
+            else:
+                monitor = {
+                    "left": capture_rect.left,
+                    "top": capture_rect.top,
+                    "width": capture_rect.right - capture_rect.left,
+                    "height": capture_rect.bottom - capture_rect.top,
+                }
+            raw = sct.grab(monitor)
+            image = Image.frombytes("RGB", raw.size, raw.rgb)
+        return _crop_screenshot(image, capture_rect)
+
+
+# ---------------------------------------------------------------------------
+# Instance management
+# ---------------------------------------------------------------------------
+
+_backend_instances: dict[str, _ScreenshotBackend] = {}
+
+
+def _get_backend(name: str) -> _ScreenshotBackend:
+    """Return a cached singleton instance for the given backend *name*."""
+    if name not in _backend_instances:
+        cls = _ScreenshotBackend.registry.get(name)
+        if cls is None:
+            raise ValueError(f"Unknown screenshot backend: {name!r}")
+        _backend_instances[name] = cls()
+    return _backend_instances[name]
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def capture(
+    capture_rect: uia.Rect | None,
+    backend: str | None = None,
+) -> tuple[Image.Image, str]:
+    """Capture a screenshot and return ``(image, backend_name_used)``."""
+    selected = backend or get_screenshot_backend()
+
+    # Build the candidate chain: all registered backends sorted by priority, or a single one.
+    if selected == "auto":
+        chain = sorted(_ScreenshotBackend.registry.values(), key=lambda c: c.priority)
+    else:
+        cls = _ScreenshotBackend.registry.get(selected)
+        if cls is None:
+            raise ValueError(f"Unknown screenshot backend: {selected!r}")
+        chain = [cls]
+
+    # Try each candidate: skip unavailable ones, catch failures and fall through.
+    for backend_cls in chain:
+        inst = _get_backend(backend_cls.name)
+        if not inst.is_available(capture_rect):
+            continue
+        try:
+            return inst.capture(capture_rect), inst.name
         except (OSError, RuntimeError, ValueError):
             logger.warning(
                 "Screenshot backend '%s' failed; trying next backend",
-                backend_name,
+                inst.name,
                 exc_info=selected != "auto",
             )
 
-    # Final safety fallback so capture always returns an image on supported hosts.
-    return capture_with_pillow(capture_rect), "pillow"
-
+    # All candidates exhausted — pillow is always present as the last resort.
+    return _get_backend("pillow").capture(capture_rect), "pillow"

--- a/src/windows_mcp/desktop/screenshot.py
+++ b/src/windows_mcp/desktop/screenshot.py
@@ -77,7 +77,10 @@ class _ScreenshotBackend:
 
     def __init_subclass__(cls, **kwargs: object) -> None:
         super().__init_subclass__(**kwargs)
-        if hasattr(cls, "name") and hasattr(cls, "priority"):
+        if "name" in cls.__dict__ and "priority" in cls.__dict__:
+            existing = _ScreenshotBackend.registry.get(cls.name)
+            if existing is not None and existing is not cls:
+                raise ValueError(f"Duplicate screenshot backend name: {cls.name!r}")
             _ScreenshotBackend.registry[cls.name] = cls
 
     def is_available(self, capture_rect: uia.Rect | None) -> bool:

--- a/src/windows_mcp/desktop/service.py
+++ b/src/windows_mcp/desktop/service.py
@@ -39,9 +39,6 @@ logger.setLevel(logging.INFO)
 
 import windows_mcp.uia as uia  # noqa: E402
 
-dxcam = screenshot_capture.dxcam
-mss = screenshot_capture.mss
-
 # Key name aliases for shortcut keys that differ from UIA SpecialKeyNames
 _KEY_ALIASES = {
     "backspace": "Back",
@@ -82,33 +79,6 @@ class Desktop:
         self.encoding = getpreferredencoding()
         self.tree = Tree(self)
         self.desktop_state = None
-        self._dxcam_cameras: dict[int, object] = {}
-
-    @staticmethod
-    def _get_screenshot_backend() -> str:
-        return screenshot_capture.get_screenshot_backend()
-
-    def _resolve_dxcam_region(
-        self, capture_rect: uia.Rect | None
-    ) -> tuple[int, tuple[int, int, int, int] | None] | None:
-        if dxcam is None:
-            return None
-        return screenshot_capture.resolve_dxcam_region(capture_rect, uia.GetMonitorsRect)
-
-    def _get_dxcam_camera(self, output_idx: int):
-        # Keep method for backward compatibility with tests and callers.
-        return screenshot_capture.get_dxcam_camera(output_idx, self._dxcam_cameras, dxcam_module=dxcam)
-
-    def _capture_with_dxcam(self, capture_rect: uia.Rect) -> Image.Image:
-        return screenshot_capture.capture_with_dxcam(
-            capture_rect,
-            uia.GetMonitorsRect,
-            self._dxcam_cameras,
-            dxcam_module=dxcam,
-        )
-
-    def _capture_with_pillow(self, capture_rect: uia.Rect | None = None) -> Image.Image:
-        return screenshot_capture.capture_with_pillow(capture_rect, self._crop_screenshot)
 
     def get_state(
         self,
@@ -1051,12 +1021,7 @@ class Desktop:
     def get_screenshot(self, capture_rect: uia.Rect | None = None) -> Image.Image:
         image, used_backend = screenshot_capture.capture(
             capture_rect=capture_rect,
-            crop_screenshot=self._crop_screenshot,
             get_monitors_rect=uia.GetMonitorsRect,
-            camera_cache=self._dxcam_cameras,
-            backend=self._get_screenshot_backend(),
-            dxcam_module=dxcam,
-            mss_module=mss,
         )
         self._last_screenshot_backend = used_backend
         return image

--- a/src/windows_mcp/desktop/service.py
+++ b/src/windows_mcp/desktop/service.py
@@ -1019,10 +1019,7 @@ class Desktop:
         )
 
     def get_screenshot(self, capture_rect: uia.Rect | None = None) -> Image.Image:
-        image, used_backend = screenshot_capture.capture(
-            capture_rect=capture_rect,
-            get_monitors_rect=uia.GetMonitorsRect,
-        )
+        image, used_backend = screenshot_capture.capture(capture_rect)
         self._last_screenshot_backend = used_backend
         return image
 

--- a/src/windows_mcp/desktop/service.py
+++ b/src/windows_mcp/desktop/service.py
@@ -1271,23 +1271,6 @@ class Desktop:
             dom_informative_nodes=tree_state.dom_informative_nodes if filtered_dom_node else [],
         )
 
-    @staticmethod
-    def _build_crop_box(capture_rect: uia.Rect, padding: int = 0) -> tuple[int, int, int, int]:
-        left_offset, top_offset, _, _ = uia.GetVirtualScreenRect()
-        return (
-            capture_rect.left - left_offset + padding,
-            capture_rect.top - top_offset + padding,
-            capture_rect.right - left_offset + padding,
-            capture_rect.bottom - top_offset + padding,
-        )
-
-    def _crop_screenshot(
-        self, screenshot: Image.Image, capture_rect: uia.Rect | None
-    ) -> Image.Image:
-        if capture_rect is None:
-            return screenshot
-        return screenshot.crop(self._build_crop_box(capture_rect))
-
     def send_notification(self, title: str, message: str, app_id: str) -> str:
         """Send a Windows toast notification with a title and message.
 

--- a/tests/test_screenshot_capture.py
+++ b/tests/test_screenshot_capture.py
@@ -15,6 +15,7 @@ from windows_mcp.desktop.screenshot import (
     _MssBackend,
     _PillowBackend,
     _ScreenshotBackend,
+    _get_backend,
     capture,
     get_screenshot_backend,
 )
@@ -303,11 +304,11 @@ class TestPillowBackend:
 
     def test_capture_falls_back_to_primary_on_grab_error_without_rect(self, monkeypatch):
         primary = Image.new("RGB", (1920, 1080), "red")
-        call_count = {"n": 0}
+        calls: list[dict[str, object]] = []
 
         def fake_grab(**kwargs):
-            call_count["n"] += 1
-            if call_count["n"] == 1:
+            calls.append(kwargs)
+            if len(calls) == 1:
                 raise OSError("grab failed")
             return primary
 
@@ -316,6 +317,7 @@ class TestPillowBackend:
         result = _PillowBackend().capture(None)
         assert result.size == (1920, 1080)
         assert result.getbbox() is not None
+        assert calls == [{"all_screens": True}, {}]
 
 
 # ---------------------------------------------------------------------------
@@ -324,6 +326,13 @@ class TestPillowBackend:
 
 
 class TestCapture:
+    def test_get_backend_caches_instance_by_name(self):
+        backend1 = _get_backend("pillow")
+        backend2 = _get_backend("pillow")
+
+        assert backend1 is backend2
+        assert isinstance(backend1, _PillowBackend)
+
     def test_explicit_pillow_returns_image_and_name(self, monkeypatch):
         fake_img = Image.new("RGB", (1920, 1080), "white")
         monkeypatch.setattr(
@@ -382,6 +391,43 @@ class TestCapture:
         # mss failed → pillow fallback
         assert backend_name == "pillow"
         assert isinstance(image, Image.Image)
+
+    def test_explicit_backend_exception_triggers_pillow_fallback(self, monkeypatch):
+        """Even an explicitly selected backend falls back to pillow on capture failure."""
+        monkeypatch.setattr(screenshot, "dxcam", None)
+
+        fake_mss = MagicMock()
+        fake_mss.mss.return_value.__enter__ = MagicMock(side_effect=OSError("mss broken"))
+        monkeypatch.setattr(screenshot, "mss", fake_mss)
+
+        fake_img = Image.new("RGB", (1920, 1080), "white")
+        monkeypatch.setattr(
+            screenshot, "ImageGrab", MagicMock(grab=MagicMock(return_value=fake_img))
+        )
+
+        image, backend_name = capture(MONITOR_0, backend="mss")
+
+        assert backend_name == "pillow"
+        assert isinstance(image, Image.Image)
+        assert image.size == (1920, 1080)
+
+    def test_explicit_dxcam_cross_monitor_rect_falls_back_to_pillow(self, monkeypatch):
+        monkeypatch.setenv("WINDOWS_MCP_SCREENSHOT_BACKEND", "dxcam")
+        monkeypatch.setattr(screenshot, "dxcam", MagicMock())
+        monkeypatch.setattr(
+            "windows_mcp.desktop.screenshot.uia.GetMonitorsRect", lambda: TWO_MONITORS
+        )
+
+        fake_img = Image.new("RGB", (3840, 1080), "blue")
+        monkeypatch.setattr(
+            screenshot, "ImageGrab", MagicMock(grab=MagicMock(return_value=fake_img))
+        )
+
+        image, backend_name = capture(Rect(0, 0, 3840, 1080), backend="dxcam")
+
+        assert backend_name == "pillow"
+        assert isinstance(image, Image.Image)
+        assert image.size == (3840, 1080)
 
     def test_capture_returns_non_empty_image(self, monkeypatch):
         """Verify the returned image has actual pixel content (not all-zero)."""

--- a/tests/test_screenshot_capture.py
+++ b/tests/test_screenshot_capture.py
@@ -66,6 +66,22 @@ class TestBackendRegistry:
 
         assert "_test_incomplete" not in _ScreenshotBackend.registry
 
+    def test_inherited_subclass_does_not_overwrite_registry(self):
+        """A subclass that inherits name/priority without overriding should not register."""
+        original = _ScreenshotBackend.registry.get("pillow")
+
+        class _ChildPillow(_PillowBackend):
+            pass  # inherits name="pillow", priority=100 but doesn't define them in __dict__
+
+        assert _ScreenshotBackend.registry["pillow"] is original
+
+    def test_duplicate_name_raises_value_error(self):
+        with pytest.raises(ValueError, match="Duplicate screenshot backend name"):
+
+            class _Conflict(_ScreenshotBackend):
+                name = "pillow"
+                priority = 50
+
     def test_auto_chain_respects_priority_order(self):
         classes = sorted(_ScreenshotBackend.registry.values(), key=lambda c: c.priority)
         names = [c.name for c in classes]

--- a/tests/test_screenshot_capture.py
+++ b/tests/test_screenshot_capture.py
@@ -1,0 +1,397 @@
+"""Unit tests for the screenshot capture module.
+
+Tests the ``capture()`` public API and each backend class directly,
+without going through ``Desktop.get_screenshot``.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PIL import Image
+
+import windows_mcp.desktop.screenshot as screenshot
+from windows_mcp.desktop.screenshot import (
+    _DxcamBackend,
+    _MssBackend,
+    _PillowBackend,
+    _ScreenshotBackend,
+    capture,
+    get_screenshot_backend,
+)
+from windows_mcp.uia import Rect
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+MONITOR_0 = Rect(0, 0, 1920, 1080)
+MONITOR_1 = Rect(1920, 0, 3840, 1080)
+TWO_MONITORS = [MONITOR_0, MONITOR_1]
+
+
+@pytest.fixture(autouse=True)
+def _isolate_backend_instances(monkeypatch):
+    """Ensure each test gets a fresh backend instance pool."""
+    monkeypatch.setattr(screenshot, "_backend_instances", {})
+
+
+# ---------------------------------------------------------------------------
+# TestBackendRegistry
+# ---------------------------------------------------------------------------
+
+
+class TestBackendRegistry:
+    def test_builtin_backends_are_registered(self):
+        reg = _ScreenshotBackend.registry
+        assert "dxcam" in reg
+        assert "mss" in reg
+        assert "pillow" in reg
+
+    def test_subclass_with_name_and_priority_is_registered(self):
+        class _Dummy(_ScreenshotBackend):
+            name = "_test_dummy"
+            priority = 999
+
+            def capture(self, capture_rect):
+                return Image.new("RGB", (1, 1))
+
+        assert _ScreenshotBackend.registry["_test_dummy"] is _Dummy
+        # Clean up so it doesn't leak to other tests.
+        _ScreenshotBackend.registry.pop("_test_dummy", None)
+
+    def test_subclass_without_priority_is_not_registered(self):
+        class _Incomplete(_ScreenshotBackend):
+            name = "_test_incomplete"
+
+        assert "_test_incomplete" not in _ScreenshotBackend.registry
+
+    def test_auto_chain_respects_priority_order(self):
+        classes = sorted(_ScreenshotBackend.registry.values(), key=lambda c: c.priority)
+        names = [c.name for c in classes]
+        assert names.index("dxcam") < names.index("mss") < names.index("pillow")
+
+
+# ---------------------------------------------------------------------------
+# TestGetScreenshotBackend
+# ---------------------------------------------------------------------------
+
+
+class TestGetScreenshotBackend:
+    @pytest.mark.parametrize("value", ["auto", "pillow", "dxcam", "mss"])
+    def test_valid_values_returned_as_is(self, monkeypatch, value):
+        monkeypatch.setenv("WINDOWS_MCP_SCREENSHOT_BACKEND", value)
+        assert get_screenshot_backend() == value
+
+    def test_invalid_value_falls_back_to_auto(self, monkeypatch):
+        monkeypatch.setenv("WINDOWS_MCP_SCREENSHOT_BACKEND", "bogus")
+        assert get_screenshot_backend() == "auto"
+
+    def test_default_is_auto(self, monkeypatch):
+        monkeypatch.delenv("WINDOWS_MCP_SCREENSHOT_BACKEND", raising=False)
+        assert get_screenshot_backend() == "auto"
+
+    def test_whitespace_and_case_insensitive(self, monkeypatch):
+        monkeypatch.setenv("WINDOWS_MCP_SCREENSHOT_BACKEND", "  Pillow  ")
+        assert get_screenshot_backend() == "pillow"
+
+
+# ---------------------------------------------------------------------------
+# TestDxcamBackend
+# ---------------------------------------------------------------------------
+
+
+class TestDxcamBackend:
+    def test_is_available_false_when_dxcam_is_none(self, monkeypatch):
+        monkeypatch.setattr(screenshot, "dxcam", None)
+        backend = _DxcamBackend()
+        assert backend.is_available(MONITOR_0) is False
+
+    def test_is_available_false_when_capture_rect_is_none(self, monkeypatch):
+        monkeypatch.setattr(screenshot, "dxcam", MagicMock())
+        monkeypatch.setattr(screenshot, "uia", MagicMock(GetMonitorsRect=lambda: TWO_MONITORS))
+        backend = _DxcamBackend()
+        assert backend.is_available(None) is False
+
+    def test_is_available_false_for_cross_monitor_rect(self, monkeypatch):
+        monkeypatch.setattr(screenshot, "dxcam", MagicMock())
+        monkeypatch.setattr(
+            "windows_mcp.desktop.screenshot.uia.GetMonitorsRect", lambda: TWO_MONITORS
+        )
+        backend = _DxcamBackend()
+        assert backend.is_available(Rect(0, 0, 3840, 1080)) is False
+
+    def test_is_available_true_for_single_monitor_rect(self, monkeypatch):
+        monkeypatch.setattr(screenshot, "dxcam", MagicMock())
+        monkeypatch.setattr(
+            "windows_mcp.desktop.screenshot.uia.GetMonitorsRect", lambda: TWO_MONITORS
+        )
+        backend = _DxcamBackend()
+        assert backend.is_available(MONITOR_1) is True
+
+    def test_resolve_region_exact_monitor_match(self, monkeypatch):
+        monkeypatch.setattr(
+            "windows_mcp.desktop.screenshot.uia.GetMonitorsRect", lambda: TWO_MONITORS
+        )
+        result = _DxcamBackend._resolve_region(MONITOR_1)
+        assert result == (1, None)
+
+    def test_resolve_region_sub_region_coordinates(self, monkeypatch):
+        monkeypatch.setattr(
+            "windows_mcp.desktop.screenshot.uia.GetMonitorsRect", lambda: TWO_MONITORS
+        )
+        sub_rect = Rect(2000, 100, 2500, 500)
+        result = _DxcamBackend._resolve_region(sub_rect)
+        assert result is not None
+        output_idx, region = result
+        assert output_idx == 1
+        # Coordinates should be relative to monitor_1's origin (1920, 0).
+        assert region == (2000 - 1920, 100 - 0, 2500 - 1920, 500 - 0)
+
+    def test_resolve_region_returns_none_for_cross_monitor(self, monkeypatch):
+        monkeypatch.setattr(
+            "windows_mcp.desktop.screenshot.uia.GetMonitorsRect", lambda: TWO_MONITORS
+        )
+        assert _DxcamBackend._resolve_region(Rect(0, 0, 3840, 1080)) is None
+
+    def test_get_camera_caches_instance(self, monkeypatch):
+        fake_camera = MagicMock()
+        fake_dxcam = MagicMock()
+        fake_dxcam.create.return_value = fake_camera
+        monkeypatch.setattr(screenshot, "dxcam", fake_dxcam)
+
+        backend = _DxcamBackend()
+        cam1 = backend._get_camera(0)
+        cam2 = backend._get_camera(0)
+        assert cam1 is cam2
+        fake_dxcam.create.assert_called_once()
+
+    def test_capture_returns_image(self, monkeypatch):
+        fake_camera = MagicMock()
+        fake_camera.grab.return_value = [[[255, 0, 0]]]
+        fake_dxcam = MagicMock()
+        fake_dxcam.create.return_value = fake_camera
+        monkeypatch.setattr(screenshot, "dxcam", fake_dxcam)
+        monkeypatch.setattr(
+            "windows_mcp.desktop.screenshot.uia.GetMonitorsRect", lambda: TWO_MONITORS
+        )
+
+        fake_image = Image.new("RGB", (100, 100), "red")
+        with patch.object(Image, "fromarray", return_value=fake_image):
+            backend = _DxcamBackend()
+            result = backend.capture(MONITOR_1)
+
+        assert isinstance(result, Image.Image)
+        assert result.size == (100, 100)
+        assert result.getbbox() is not None
+
+    def test_capture_raises_on_none_frame(self, monkeypatch):
+        fake_camera = MagicMock()
+        fake_camera.grab.return_value = None
+        fake_dxcam = MagicMock()
+        fake_dxcam.create.return_value = fake_camera
+        monkeypatch.setattr(screenshot, "dxcam", fake_dxcam)
+        monkeypatch.setattr(
+            "windows_mcp.desktop.screenshot.uia.GetMonitorsRect", lambda: TWO_MONITORS
+        )
+
+        backend = _DxcamBackend()
+        with pytest.raises(RuntimeError, match="no frame"):
+            backend.capture(MONITOR_1)
+
+
+# ---------------------------------------------------------------------------
+# TestMssBackend
+# ---------------------------------------------------------------------------
+
+
+class TestMssBackend:
+    def test_is_available_false_when_mss_is_none(self, monkeypatch):
+        monkeypatch.setattr(screenshot, "mss", None)
+        assert _MssBackend().is_available(MONITOR_0) is False
+
+    def test_is_available_true_when_mss_exists(self, monkeypatch):
+        monkeypatch.setattr(screenshot, "mss", MagicMock())
+        assert _MssBackend().is_available(MONITOR_0) is True
+
+    def _make_fake_mss(self, width: int, height: int) -> MagicMock:
+        fake_shot = MagicMock()
+        fake_shot.size = (width, height)
+        fake_shot.rgb = b"\xff\x00\x00" * (width * height)
+        fake_sct = MagicMock()
+        fake_sct.grab.return_value = fake_shot
+        fake_sct.monitors = [{"left": 0, "top": 0, "width": width, "height": height}]
+        fake_ctx = MagicMock()
+        fake_ctx.__enter__ = MagicMock(return_value=fake_sct)
+        fake_ctx.__exit__ = MagicMock(return_value=False)
+        fake_module = MagicMock()
+        fake_module.mss.return_value = fake_ctx
+        return fake_module, fake_sct
+
+    def test_capture_with_rect_builds_correct_monitor(self, monkeypatch):
+        fake_module, fake_sct = self._make_fake_mss(500, 400)
+        monkeypatch.setattr(screenshot, "mss", fake_module)
+        monkeypatch.setattr(
+            "windows_mcp.desktop.screenshot.uia.GetVirtualScreenRect",
+            lambda: (0, 0, 1920, 1080),
+        )
+
+        backend = _MssBackend()
+        result = backend.capture(Rect(100, 200, 600, 600))
+
+        assert isinstance(result, Image.Image)
+        call_args = fake_sct.grab.call_args[0][0]
+        assert call_args == {"left": 100, "top": 200, "width": 500, "height": 400}
+
+    def test_capture_without_rect_uses_full_screen(self, monkeypatch):
+        fake_module, fake_sct = self._make_fake_mss(1920, 1080)
+        monkeypatch.setattr(screenshot, "mss", fake_module)
+
+        backend = _MssBackend()
+        result = backend.capture(None)
+
+        assert isinstance(result, Image.Image)
+        assert result.size == (1920, 1080)
+        # Should have used monitors[0]
+        call_args = fake_sct.grab.call_args[0][0]
+        assert call_args == fake_sct.monitors[0]
+
+
+# ---------------------------------------------------------------------------
+# TestPillowBackend
+# ---------------------------------------------------------------------------
+
+
+class TestPillowBackend:
+    def test_is_available_always_true(self):
+        assert _PillowBackend().is_available(None) is True
+        assert _PillowBackend().is_available(MONITOR_0) is True
+
+    def test_capture_returns_image_with_correct_size(self, monkeypatch):
+        fake_img = Image.new("RGB", (1920, 1080), "blue")
+        monkeypatch.setattr(
+            screenshot, "ImageGrab", MagicMock(grab=MagicMock(return_value=fake_img))
+        )
+        monkeypatch.setattr(
+            "windows_mcp.desktop.screenshot.uia.GetVirtualScreenRect",
+            lambda: (0, 0, 1920, 1080),
+        )
+
+        result = _PillowBackend().capture(None)
+        assert result.size == (1920, 1080)
+        assert result.getbbox() is not None
+
+    def test_capture_falls_back_on_grab_error_with_rect(self, monkeypatch):
+        full_screen = Image.new("RGB", (3840, 1080), "green")
+        call_count = {"n": 0}
+
+        def fake_grab(**kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise OSError("grab failed")
+            return full_screen
+
+        monkeypatch.setattr(screenshot, "ImageGrab", MagicMock(grab=fake_grab))
+        monkeypatch.setattr(
+            "windows_mcp.desktop.screenshot.uia.GetVirtualScreenRect",
+            lambda: (0, 0, 3840, 1080),
+        )
+
+        result = _PillowBackend().capture(Rect(1920, 0, 3840, 1080))
+        assert isinstance(result, Image.Image)
+        # Should have fallen back and cropped
+        assert result.size == (1920, 1080)
+
+    def test_capture_falls_back_to_primary_on_grab_error_without_rect(self, monkeypatch):
+        primary = Image.new("RGB", (1920, 1080), "red")
+        call_count = {"n": 0}
+
+        def fake_grab(**kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise OSError("grab failed")
+            return primary
+
+        monkeypatch.setattr(screenshot, "ImageGrab", MagicMock(grab=fake_grab))
+
+        result = _PillowBackend().capture(None)
+        assert result.size == (1920, 1080)
+        assert result.getbbox() is not None
+
+
+# ---------------------------------------------------------------------------
+# TestCapture (public API)
+# ---------------------------------------------------------------------------
+
+
+class TestCapture:
+    def test_explicit_pillow_returns_image_and_name(self, monkeypatch):
+        fake_img = Image.new("RGB", (1920, 1080), "white")
+        monkeypatch.setattr(
+            screenshot, "ImageGrab", MagicMock(grab=MagicMock(return_value=fake_img))
+        )
+
+        image, backend_name = capture(None, backend="pillow")
+        assert backend_name == "pillow"
+        assert isinstance(image, Image.Image)
+        assert image.size == (1920, 1080)
+
+    def test_unknown_backend_raises_value_error(self):
+        with pytest.raises(ValueError, match="nonexistent"):
+            capture(None, backend="nonexistent")
+
+    def test_auto_skips_dxcam_when_capture_rect_is_none(self, monkeypatch):
+        monkeypatch.setattr(screenshot, "dxcam", MagicMock())
+        monkeypatch.setattr(screenshot, "mss", None)
+        fake_img = Image.new("RGB", (1920, 1080), "white")
+        monkeypatch.setattr(
+            screenshot, "ImageGrab", MagicMock(grab=MagicMock(return_value=fake_img))
+        )
+
+        image, backend_name = capture(None, backend="auto")
+        # dxcam is_available returns False for None rect, mss is None → pillow
+        assert backend_name == "pillow"
+
+    def test_auto_falls_back_when_all_unavailable(self, monkeypatch):
+        monkeypatch.setattr(screenshot, "dxcam", None)
+        monkeypatch.setattr(screenshot, "mss", None)
+        fake_img = Image.new("RGB", (800, 600), "blue")
+        monkeypatch.setattr(
+            screenshot, "ImageGrab", MagicMock(grab=MagicMock(return_value=fake_img))
+        )
+
+        image, backend_name = capture(None, backend="auto")
+        assert backend_name == "pillow"
+        assert image.size == (800, 600)
+        assert image.getbbox() is not None
+
+    def test_backend_exception_triggers_fallback(self, monkeypatch):
+        """When an available backend's capture() raises, fall through to the next."""
+        monkeypatch.setattr(screenshot, "dxcam", None)
+
+        # Make mss available but its capture raises
+        fake_mss = MagicMock()
+        fake_mss.mss.return_value.__enter__ = MagicMock(side_effect=OSError("mss broken"))
+        monkeypatch.setattr(screenshot, "mss", fake_mss)
+
+        fake_img = Image.new("RGB", (1920, 1080), "white")
+        monkeypatch.setattr(
+            screenshot, "ImageGrab", MagicMock(grab=MagicMock(return_value=fake_img))
+        )
+
+        image, backend_name = capture(MONITOR_0, backend="auto")
+        # mss failed → pillow fallback
+        assert backend_name == "pillow"
+        assert isinstance(image, Image.Image)
+
+    def test_capture_returns_non_empty_image(self, monkeypatch):
+        """Verify the returned image has actual pixel content (not all-zero)."""
+        colored_img = Image.new("RGB", (640, 480), (255, 128, 0))
+        monkeypatch.setattr(
+            screenshot, "ImageGrab", MagicMock(grab=MagicMock(return_value=colored_img))
+        )
+
+        image, _ = capture(None, backend="pillow")
+        assert image.getbbox() is not None
+        # Spot-check a pixel
+        r, g, b = image.getpixel((0, 0))
+        assert (r, g, b) == (255, 128, 0)

--- a/tests/test_snapshot_display_filter.py
+++ b/tests/test_snapshot_display_filter.py
@@ -47,7 +47,6 @@ class TestDisplayFiltering:
     def desktop(self):
         with patch.object(Desktop, "__init__", lambda self: None):
             desktop = Desktop()
-            desktop._dxcam_cameras = {}
             return desktop
 
     def test_get_display_union_rect(self, desktop):
@@ -144,10 +143,12 @@ class TestDisplayFiltering:
 
     def test_get_screenshot_uses_display_bbox_for_direct_capture(self, desktop):
         capture_rect = Rect(1920, 0, 3840, 1080)
-        with patch("windows_mcp.desktop.service.dxcam", None):
+        with patch("windows_mcp.desktop.screenshot.dxcam", None):
             with patch("windows_mcp.desktop.screenshot.ImageGrab.grab") as mock_grab:
-                mock_grab.return_value = Image.new("RGB", (1920, 1080), "white")
-                screenshot = desktop.get_screenshot(capture_rect=capture_rect)
+                with patch("windows_mcp.desktop.screenshot.get_screenshot_backend") as mock_screenshot_backend:
+                    mock_grab.return_value = Image.new("RGB", (1920, 1080), "white")
+                    mock_screenshot_backend.return_value = "pillow"  # Ensure we test the Pillow path
+                    screenshot = desktop.get_screenshot(capture_rect=capture_rect)
 
         assert screenshot.size == (1920, 1080)
         assert mock_grab.call_args.kwargs == {
@@ -163,8 +164,8 @@ class TestDisplayFiltering:
         fake_dxcam.create.return_value = fake_camera
 
         monkeypatch.setenv("WINDOWS_MCP_SCREENSHOT_BACKEND", "dxcam")
-        monkeypatch.setattr("windows_mcp.desktop.service.dxcam", fake_dxcam)
         monkeypatch.setattr("windows_mcp.desktop.screenshot.dxcam", fake_dxcam)
+        monkeypatch.setattr("windows_mcp.desktop.screenshot._DXCAM_CAMERA_CACHE", {})
         monkeypatch.setattr(
             "windows_mcp.desktop.service.uia.GetMonitorsRect",
             lambda: [Rect(0, 0, 1920, 1080), Rect(1920, 0, 3840, 1080)],
@@ -185,7 +186,6 @@ class TestDisplayFiltering:
         fake_dxcam = MagicMock()
 
         monkeypatch.setenv("WINDOWS_MCP_SCREENSHOT_BACKEND", "dxcam")
-        monkeypatch.setattr("windows_mcp.desktop.service.dxcam", fake_dxcam)
         monkeypatch.setattr("windows_mcp.desktop.screenshot.dxcam", fake_dxcam)
         monkeypatch.setattr(
             "windows_mcp.desktop.service.uia.GetMonitorsRect",
@@ -215,9 +215,7 @@ class TestDisplayFiltering:
         fake_mss_module = MagicMock(mss=MagicMock(return_value=fake_mss_ctx))
 
         monkeypatch.setenv("WINDOWS_MCP_SCREENSHOT_BACKEND", "auto")
-        monkeypatch.setattr("windows_mcp.desktop.service.dxcam", None)
         monkeypatch.setattr("windows_mcp.desktop.screenshot.dxcam", None)
-        monkeypatch.setattr("windows_mcp.desktop.service.mss", fake_mss_module)
         monkeypatch.setattr("windows_mcp.desktop.screenshot.mss", fake_mss_module)
         screenshot = desktop.get_screenshot(capture_rect=capture_rect)
 

--- a/tests/test_snapshot_display_filter.py
+++ b/tests/test_snapshot_display_filter.py
@@ -165,7 +165,7 @@ class TestDisplayFiltering:
         monkeypatch.setattr("windows_mcp.desktop.screenshot.dxcam", fake_dxcam)
         monkeypatch.setattr("windows_mcp.desktop.screenshot._DXCAM_CAMERA_CACHE", {})
         monkeypatch.setattr(
-            "windows_mcp.desktop.service.uia.GetMonitorsRect",
+            "windows_mcp.desktop.screenshot.uia.GetMonitorsRect",
             lambda: [Rect(0, 0, 1920, 1080), Rect(1920, 0, 3840, 1080)],
         )
         with patch(
@@ -186,7 +186,7 @@ class TestDisplayFiltering:
         monkeypatch.setenv("WINDOWS_MCP_SCREENSHOT_BACKEND", "dxcam")
         monkeypatch.setattr("windows_mcp.desktop.screenshot.dxcam", fake_dxcam)
         monkeypatch.setattr(
-            "windows_mcp.desktop.service.uia.GetMonitorsRect",
+            "windows_mcp.desktop.screenshot.uia.GetMonitorsRect",
             lambda: [Rect(0, 0, 1920, 1080), Rect(1920, 0, 3840, 1080)],
         )
         with patch("windows_mcp.desktop.screenshot.ImageGrab.grab") as mock_grab:

--- a/tests/test_snapshot_display_filter.py
+++ b/tests/test_snapshot_display_filter.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from PIL import Image
 
+from windows_mcp.desktop.screenshot import _crop_screenshot  # noqa
 from windows_mcp.desktop.service import Desktop
 from windows_mcp.desktop.views import DesktopState, Size, Status, Window
 from windows_mcp.tree.views import BoundingBox, Center, ScrollElementNode, TreeElementNode, TreeState
@@ -133,12 +134,9 @@ class TestDisplayFiltering:
 
     def test_crop_screenshot_to_display_region(self, desktop):
         screenshot = Image.new("RGB", (3840, 1080), "white")
-        with patch("windows_mcp.desktop.service.uia.GetVirtualScreenRect") as mock_virtual_rect:
+        with patch("windows_mcp.desktop.screenshot.uia.GetVirtualScreenRect") as mock_virtual_rect:
             mock_virtual_rect.return_value = (0, 0, 3840, 1080)
-            cropped = desktop._crop_screenshot(
-                screenshot,
-                Rect(1920, 0, 3840, 1080),
-            )
+            cropped = _crop_screenshot(screenshot, Rect(1920, 0, 3840, 1080))
         assert cropped.size == (1920, 1080)
 
     def test_get_screenshot_uses_display_bbox_for_direct_capture(self, desktop):

--- a/tests/test_snapshot_display_filter.py
+++ b/tests/test_snapshot_display_filter.py
@@ -163,7 +163,7 @@ class TestDisplayFiltering:
 
         monkeypatch.setenv("WINDOWS_MCP_SCREENSHOT_BACKEND", "dxcam")
         monkeypatch.setattr("windows_mcp.desktop.screenshot.dxcam", fake_dxcam)
-        monkeypatch.setattr("windows_mcp.desktop.screenshot._DXCAM_CAMERA_CACHE", {})
+        monkeypatch.setattr("windows_mcp.desktop.screenshot._backend_instances", {})
         monkeypatch.setattr(
             "windows_mcp.desktop.screenshot.uia.GetMonitorsRect",
             lambda: [Rect(0, 0, 1920, 1080), Rect(1920, 0, 3840, 1080)],


### PR DESCRIPTION
### Summary

- **Decouple screenshot logic from `Desktop`**: Move screenshot-related state and functions out of `Desktop` (service.py) into the `screenshot` module, eliminating unused delegation methods and reducing `Desktop`'s responsibilities.
- **Simplify `capture()` parameters**: Remove unnecessary callable/injection parameters (`crop_screenshot`, `get_monitors_rect`, `dxcam_module`, `mss_module`, `camera_cache`) that were passed through solely for testability but made the API confusing and brittle. Each backend now accesses what it needs directly.
- **Introduce `ScreenshotBackend` class hierarchy**: Replace the flat `capture_with_*` functions and manual if/elif dispatch with an OOP design using `__init_subclass__` for automatic backend registration. Adding a new backend now only requires defining a single class with `name` and `priority`.
- **Add comprehensive unit tests**: New `test_screenshot_capture.py` with 38 test cases covering the `capture()` API, each backend class, the auto-registration mechanism, and edge cases like fallback chains and error recovery.

### Motivation

The `Desktop` class had accumulated several screenshot-related methods (`_capture_with_dxcam`, `_capture_with_pillow`, `_get_dxcam_camera`, `_resolve_dxcam_region`, `_get_screenshot_backend`, `_crop_screenshot`, `_build_crop_box`) that were thin wrappers delegating to `screenshot.py` functions. These wrappers added no value — they simply forwarded calls — yet inflated `Desktop`'s surface area and obscured where the real logic lived.

The `capture()` function signature had grown to accept 7 parameters, most of which were dependency-injection hooks introduced purely for unit testing:

```python
# Before: confusing signature with test-only parameters
def capture(
    capture_rect,
    crop_screenshot: Callable,      # always Desktop._crop_screenshot
    get_monitors_rect: Callable,    # always uia.GetMonitorsRect
    camera_cache: dict,             # always Desktop._dxcam_cameras
    backend: str | None = None,
    dxcam_module=None,              # always the dxcam module
    mss_module=None,                # always the mss module
) -> tuple[Image.Image, str]:
```

This created several problems:
- **Unnecessary indirection**: Every call site passed the same objects. If the actual argument never varies, the function should just use it directly.
- **Backend-specific parameters leaking into the generic API**: `camera_cache` and `dxcam_module` only matter for the dxcam backend; passing them through the generic `capture()` is misleading — callers might expect them to affect other backends.
- **Module-level globals introduced for testability**: `_DXCAM_CAMERA_CACHE` was a module global dict that existed primarily so tests could reset it, making the code harder to follow.

### What changed

**`screenshot.py`** — Major restructure:
- Introduced `_ScreenshotBackend` base class with `__init_subclass__` auto-registration into `registry`.
- Three backend subclasses: `_DxcamBackend` (priority=10), `_MssBackend` (priority=20), `_PillowBackend` (priority=100).
- Each backend encapsulates its own availability check (`is_available`) and capture logic (`capture`).
- `_DxcamBackend` owns its camera cache as an instance attribute and its monitor region resolution as a static method.
- `capture()` reduced to 2 parameters: `capture(capture_rect, backend=None)`.
- `get_screenshot_backend()` validates against the dynamic registry instead of a hardcoded set.
- Removed: `capture_with_dxcam()`, `capture_with_mss()`, `capture_with_pillow()`, `get_dxcam_camera()`, `_DXCAM_CAMERA_CACHE`, `resolve_dxcam_region()`, `_auto_backend_chain()`.

**`service.py`** — Simplified:
- Removed `Desktop._dxcam_cameras`, `_get_screenshot_backend`, `_resolve_dxcam_region`, `_get_dxcam_camera`, `_capture_with_dxcam`, `_capture_with_pillow`, `_crop_screenshot`, `_build_crop_box`.
- Removed module-level `dxcam = screenshot_capture.dxcam` / `mss = screenshot_capture.mss` aliases.
- `Desktop.get_screenshot()` now simply calls `screenshot_capture.capture(capture_rect)`.

**`test_snapshot_display_filter.py`** — Updated mock targets:
- All `patch("windows_mcp.desktop.service.dxcam", ...)` / `service.mss` references replaced with `screenshot.*` targets.
- `_DXCAM_CAMERA_CACHE` mock replaced with `_backend_instances` reset.

**`test_screenshot_capture.py`** — New file, 38 test cases:
- `TestBackendRegistry`: auto-registration, priority ordering, incomplete subclass handling.
- `TestGetScreenshotBackend`: valid/invalid env vars, defaults, case insensitivity.
- `TestDxcamBackend`: availability checks, region resolution (exact match, sub-region coordinates, cross-monitor), camera caching, capture success/failure.
- `TestMssBackend`: availability, monitor dict construction, full-screen path.
- `TestPillowBackend`: always-available, error fallback with/without capture rect.
- `TestCapture`: explicit backend, unknown backend error, auto chain fallback, exception recovery, safety fallback, image content verification.

### Test plan

- [x] `ruff check . && ruff format --check .` — lint passes
- [x] `pytest tests/test_screenshot_capture.py -v` — 38 new tests pass
- [x] `pytest tests/test_snapshot_display_filter.py -v` — 18 existing tests pass (no regressions)
