### PR TITLE
fix: remove double-crop in pillow and mss backends for region captures

### DIFF
--- a/src/windows_mcp/desktop/screenshot.py
+++ b/src/windows_mcp/desktop/screenshot.py
@@ -175,10 +175,13 @@ class _PillowBackend(_ScreenshotBackend):
                     "Failed to capture selected region directly, "
                     "falling back to virtual screen crop"
                 )
+                # Fallback: grab full virtual screen then crop to the requested region.
                 return _crop_screenshot(ImageGrab.grab(all_screens=True), capture_rect)
             logger.warning("Failed to capture virtual screen, using primary screen")
             screenshot = ImageGrab.grab()
-        return _crop_screenshot(screenshot, capture_rect)
+        # Success path: ImageGrab.grab(bbox=...) already returned the exact region,
+        # so no further cropping is needed.
+        return screenshot
 
 
 class _MssBackend(_ScreenshotBackend):
@@ -205,7 +208,9 @@ class _MssBackend(_ScreenshotBackend):
                 }
             raw = sct.grab(monitor)
             image = Image.frombytes("RGB", raw.size, raw.rgb)
-        return _crop_screenshot(image, capture_rect)
+        # mss.grab(monitor) already captures exactly the requested region,
+        # so no further cropping is needed.
+        return image
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_screenshot_capture.py
+++ b/tests/test_screenshot_capture.py
@@ -3,7 +3,7 @@
 Tests the ``capture()`` public API and each backend class directly,
 without going through ``Desktop.get_screenshot``.
 """
-
+from typing import Tuple
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -230,7 +230,7 @@ class TestMssBackend:
         monkeypatch.setattr(screenshot, "mss", MagicMock())
         assert _MssBackend().is_available(MONITOR_0) is True
 
-    def _make_fake_mss(self, width: int, height: int) -> MagicMock:
+    def _make_fake_mss(self, width: int, height: int) -> Tuple[MagicMock, MagicMock]:
         fake_shot = MagicMock()
         fake_shot.size = (width, height)
         fake_shot.rgb = b"\xff\x00\x00" * (width * height)
@@ -258,6 +258,23 @@ class TestMssBackend:
         assert isinstance(result, Image.Image)
         call_args = fake_sct.grab.call_args[0][0]
         assert call_args == {"left": 100, "top": 200, "width": 500, "height": 400}
+
+    def test_capture_with_non_origin_rect_returns_correct_content(self, monkeypatch):
+        """Verify mss capture of a non-primary monitor region is not corrupted by double-crop."""
+        width, height = 1920, 1080
+        fake_module, _ = self._make_fake_mss(width, height)
+        monkeypatch.setattr(screenshot, "mss", fake_module)
+        monkeypatch.setattr(
+            "windows_mcp.desktop.screenshot.uia.GetVirtualScreenRect",
+            lambda: (0, 0, 3840, 1080),
+        )
+
+        # capture_rect on second monitor — image origin is (0,0), not (1920,0)
+        result = _MssBackend().capture(Rect(1920, 0, 3840, 1080))
+
+        assert result.size == (width, height)
+        # The image should retain actual content, not be black from out-of-bounds crop.
+        assert result.getbbox() is not None
 
     def test_capture_without_rect_uses_full_screen(self, monkeypatch):
         fake_module, fake_sct = self._make_fake_mss(1920, 1080)
@@ -295,6 +312,24 @@ class TestPillowBackend:
 
         result = _PillowBackend().capture(None)
         assert result.size == (1920, 1080)
+        assert result.getbbox() is not None
+
+    def test_capture_with_non_origin_rect_returns_correct_content(self, monkeypatch):
+        """Verify pillow capture of a non-primary monitor region is not corrupted by double-crop."""
+        fake_img = Image.new("RGB", (1920, 1080), "blue")
+        monkeypatch.setattr(
+            screenshot, "ImageGrab", MagicMock(grab=MagicMock(return_value=fake_img))
+        )
+        monkeypatch.setattr(
+            "windows_mcp.desktop.screenshot.uia.GetVirtualScreenRect",
+            lambda: (0, 0, 3840, 1080),
+        )
+
+        # capture_rect on second monitor — ImageGrab.grab(bbox=...) already returns the region
+        result = _PillowBackend().capture(Rect(1920, 0, 3840, 1080))
+
+        assert result.size == (1920, 1080)
+        # The image should retain actual content, not be black from out-of-bounds crop.
         assert result.getbbox() is not None
 
     def test_capture_falls_back_on_grab_error_with_rect(self, monkeypatch):

--- a/tests/test_snapshot_display_filter.py
+++ b/tests/test_snapshot_display_filter.py
@@ -190,7 +190,7 @@ class TestDisplayFiltering:
             lambda: [Rect(0, 0, 1920, 1080), Rect(1920, 0, 3840, 1080)],
         )
         with patch("windows_mcp.desktop.screenshot.ImageGrab.grab") as mock_grab:
-            mock_grab.return_value = Image.new("RGB", (1920, 1080), "white")
+            mock_grab.return_value = Image.new("RGB", (3840, 1080), "white")
             screenshot = desktop.get_screenshot(capture_rect=capture_rect)
 
         assert screenshot.size == (3840, 1080)


### PR DESCRIPTION
## Summary

Fix a pre-existing bug discovered during [PR #202](https://github.com/CursorTouch/Windows-MCP/pull/202) code review (Copilot comments [2 and 3](https://github.com/CursorTouch/Windows-MCP/pull/202#discussion_r3067707661)): `_PillowBackend` and `_MssBackend` incorrectly applied `_crop_screenshot()` on the success path, double-cropping an already region-captured image with absolute virtual-screen coordinates.

## Root cause

When `capture_rect` is provided:
- `ImageGrab.grab(bbox=...)` already returns only the requested region (image origin at `(0, 0)`)
- `mss.grab(monitor)` likewise returns only the requested region

Both backends then called `_crop_screenshot(image, capture_rect)`, which computed a crop box using absolute virtual-screen coordinates (via `_build_crop_box` → `uia.GetVirtualScreenRect()`). Applying these absolute coordinates to an image whose origin is already `(0, 0)` caused:
- **Non-primary monitor regions** (e.g., `Rect(1920, 0, 3840, 1080)`): crop box starts at `x=1920` on a `1920px`-wide image → entirely out-of-bounds → **black image**
- **Primary monitor regions** (e.g., `Rect(0, 0, 1920, 1080)`): crop box matches image size → effectively a no-op → no visible issue

This is why the bug went unnoticed — it only manifests for non-primary monitor captures when `dxcam` is unavailable or fails (since `dxcam` handles region capture without `_crop_screenshot`).

## How to reproduce

> Under normal installation the bug does not surface (or has an extremely low probability of surfacing) because `dxcam` — a required dependency — handles single-monitor region captures without `_crop_screenshot`.

1. Uninstall `dxcam` so the capture backend falls back to pillow/mss:
   ```bash
   uv pip uninstall dxcam
   ```
2. Start the MCP server (skip dependency sync to keep dxcam removed):
   ```bash
   uv run --no-sync windows-mcp
   ```
3. On a **dual-monitor** setup, invoke the `Screenshot` tool requesting only the **second display**:
   ```
   Screenshot(display=[2])
   ```
4. **Result**: the returned screenshot is an entirely **black image** instead of the actual second-monitor content.

  <img width="1533" height="1019" alt="5444c55d9eb9050f2d74d8171cb98e50" src="https://github.com/user-attachments/assets/a3ea35d4-93eb-4ed2-bb87-fa308186451a" />


## Fix

- **`_PillowBackend.capture()`**: Return `screenshot` directly on the success path. Keep `_crop_screenshot` only in the fallback path where a full virtual-screen grab needs cropping.
- **`_MssBackend.capture()`**: Return `image` directly — `mss.grab(monitor)` already captures the exact region.

## Test changes

- Added `test_capture_with_non_origin_rect_returns_correct_content` to both `TestMssBackend` and `TestPillowBackend` — these verify that capturing a second-monitor region (`Rect(1920, 0, 3840, 1080)`) returns an image with actual content, not black pixels.
- Fixed `test_get_screenshot_falls_back_to_pillow_when_dxcam_region_is_unsupported` in `test_snapshot_display_filter.py` — the mock was returning a `(1920, 1080)` image for a `bbox=(0, 0, 3840, 1080)` grab, then relying on PIL's crop-padding behavior to expand it to `(3840, 1080)`. Updated the mock to return a correctly-sized `(3840, 1080)` image.

## Test plan

- [x] `pytest tests/test_screenshot_capture.py -v` — 42 passed
- [x] `pytest tests/test_snapshot_display_filter.py -v` — 18 passed (no regressions)
