### PR TITLE
Fix PowerShell tool missing environment variables when launched by MCP hosts

### DIFF
--- a/src/windows_mcp/desktop/powershell.py
+++ b/src/windows_mcp/desktop/powershell.py
@@ -6,12 +6,73 @@ import ctypes.wintypes
 import logging
 import os
 import shutil
-import socket
 import subprocess
 
 from windows_mcp.desktop.utils import run_with_graceful_timeout
 
 logger = logging.getLogger(__name__)
+
+
+def _read_reg_env(hkey: int, subkey: str) -> tuple[dict[str, str], str, str]:
+    """Read all environment variables from a registry key.
+
+    Returns (vars, path, pathext) where *vars* is a dict of name->value
+    (excluding PATH/PATHEXT), and *path*/*pathext* are the raw expanded
+    values for those two special keys (empty string if absent).
+    """
+    import winreg
+
+    variables: dict[str, str] = {}
+    path = ""
+    pathext = ""
+
+    try:
+        with winreg.OpenKey(hkey, subkey) as key:
+            i = 0
+            while True:
+                try:
+                    name, value, reg_type = winreg.EnumValue(key, i)
+                    if reg_type == winreg.REG_EXPAND_SZ:
+                        value = winreg.ExpandEnvironmentStrings(value)
+                    upper = name.upper()
+                    if upper == "PATH":
+                        path = value
+                    elif upper == "PATHEXT":
+                        pathext = value
+                    else:
+                        variables[name] = value
+                    i += 1
+                except OSError:
+                    break
+    except OSError:
+        pass
+
+    return variables, path, pathext
+
+
+def _dedup_path(*segments: str) -> str:
+    """Join PATH segments and deduplicate entries (case-insensitive)."""
+    seen = set()
+    deduped = []
+    for p in ";".join(filter(None, segments)).split(";"):
+        norm = p.lower().rstrip("\\")
+        if norm and norm not in seen:
+            seen.add(norm)
+            deduped.append(p)
+    return ";".join(deduped)
+
+
+def _win32_name(dll: str, func: str) -> str:
+    """Call a Win32 GetXxxNameW function that writes into a WCHAR buffer."""
+    buf = ctypes.create_unicode_buffer(256)
+    size = ctypes.wintypes.DWORD(256)
+    fn = getattr(ctypes.windll, dll)
+    if getattr(fn, func)(buf, ctypes.byref(size)):
+        return buf.value
+    return ""
+
+
+_FALLBACK_PATHEXT = ".COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC;.CPL;.PY;.PYW"
 
 
 def _prepare_env() -> dict[str, str]:
@@ -22,80 +83,54 @@ def _prepare_env() -> dict[str, str]:
     from os.environ and fills in missing variables from:
       1. System-level env vars from the registry (HKLM)
       2. User-level env vars from the registry (HKCU)
-      3. Dynamic vars (COMPUTERNAME, USERNAME, etc.) via Win32 API / stdlib
+      3. Dynamic vars (COMPUTERNAME, USERNAME, etc.) via Win32 API
     Existing values in os.environ are never overwritten, only missing ones
     are supplemented. PATH is special-cased: registry paths are prepended.
     """
     env = os.environ.copy()
 
-    # 1) Supplement missing vars from registry
-    machine_path = ""
     try:
         import winreg
 
-        # System-level environment variables
-        machine_pathext = ""
-        with winreg.OpenKey(
+        machine_vars, machine_path, machine_pathext = _read_reg_env(
             winreg.HKEY_LOCAL_MACHINE,
             r"SYSTEM\CurrentControlSet\Control\Session Manager\Environment",
-        ) as key:
-            i = 0
-            while True:
-                try:
-                    name, value, _ = winreg.EnumValue(key, i)
-                    upper = name.upper()
-                    if upper == "PATH":
-                        machine_path = value
-                    elif upper == "PATHEXT":
-                        machine_pathext = value
-                    else:
-                        env.setdefault(name, value)
-                    i += 1
-                except OSError:
-                    break
+        )
+        user_vars, user_path, user_pathext = _read_reg_env(winreg.HKEY_CURRENT_USER, r"Environment")
 
-        # User-level environment variables
-        user_path = ""
-        try:
-            with winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"Environment") as key:
-                i = 0
-                while True:
-                    try:
-                        name, value, _ = winreg.EnumValue(key, i)
-                        if name.upper() == "PATH":
-                            user_path = value
-                        else:
-                            env.setdefault(name, value)
-                        i += 1
-                    except OSError:
-                        break
-        except OSError:
-            pass
+        # Supplement missing vars. User-level (HKCU) takes precedence over
+        # system-level (HKLM) for same-named keys, matching Windows' resolution order.
+        for name, value in {**machine_vars, **user_vars}.items():
+            env.setdefault(name, value)
 
-        # PATH: prepend registry paths to ensure system executables are discoverable
-        registry_path = ";".join(filter(None, [machine_path, user_path]))
-        if registry_path:
-            env["PATH"] = ";".join(filter(None, [registry_path, env.get("PATH", "")]))
+        # PATH: prepend registry paths, deduplicated
+        if machine_path or user_path:
+            env["PATH"] = _dedup_path(machine_path, user_path, env.get("PATH", ""))
 
-        # PATHEXT: use registry value if the inherited one looks incomplete (e.g. venv strips it)
-        if machine_pathext and ".EXE" not in env.get("PATHEXT", ""):
-            env["PATHEXT"] = machine_pathext
+        # PATHEXT: use registry value if the inherited one looks incomplete
+        effective_pathext = user_pathext or machine_pathext
+        if effective_pathext and ".EXE" not in env.get("PATHEXT", ""):
+            env["PATHEXT"] = effective_pathext
 
     except Exception:
         logger.debug("Failed to read environment from registry")
         if ".EXE" not in env.get("PATHEXT", ""):
-            env["PATHEXT"] = ".COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC;.CPL;.PY;.PYW"
+            env["PATHEXT"] = _FALLBACK_PATHEXT
 
-    # 2) Dynamic variables not stored in registry env keys — only fill if missing
+    # Dynamic variables not stored in registry — only fill if missing
     if not env.get("COMPUTERNAME"):
-        env["COMPUTERNAME"] = socket.gethostname().upper()
+        try:
+            computer_name = _win32_name("kernel32", "GetComputerNameW")
+            if computer_name:
+                env["COMPUTERNAME"] = computer_name
+        except Exception as e:
+            logger.debug("Failed to get COMPUTERNAME via Win32 API: %s", e)
 
     if not env.get("USERNAME"):
         try:
-            buf = ctypes.create_unicode_buffer(256)
-            size = ctypes.wintypes.DWORD(256)
-            if ctypes.windll.advapi32.GetUserNameW(buf, ctypes.byref(size)):
-                env["USERNAME"] = buf.value
+            user_name = _win32_name("advapi32", "GetUserNameW")
+            if user_name:
+                env["USERNAME"] = user_name
         except Exception as e:
             logger.debug("Failed to get USERNAME via Win32 API: %s", e)
 

--- a/src/windows_mcp/desktop/powershell.py
+++ b/src/windows_mcp/desktop/powershell.py
@@ -1,14 +1,105 @@
 """Static PowerShell command executor utility."""
 
 import base64
+import ctypes
+import ctypes.wintypes
 import logging
 import os
 import shutil
+import socket
 import subprocess
 
 from windows_mcp.desktop.utils import run_with_graceful_timeout
 
 logger = logging.getLogger(__name__)
+
+
+def _prepare_env() -> dict[str, str]:
+    """Prepare a complete environment block for the PowerShell subprocess.
+
+    MCP hosts (e.g. Claude Desktop) may launch this server with a stripped
+    environment block missing session-level variables. This function starts
+    from os.environ and fills in missing variables from:
+      1. System-level env vars from the registry (HKLM)
+      2. User-level env vars from the registry (HKCU)
+      3. Dynamic vars (COMPUTERNAME, USERNAME, etc.) via Win32 API / stdlib
+    Existing values in os.environ are never overwritten, only missing ones
+    are supplemented. PATH is special-cased: registry paths are prepended.
+    """
+    env = os.environ.copy()
+
+    # 1) Supplement missing vars from registry
+    machine_path = ""
+    try:
+        import winreg
+
+        # System-level environment variables
+        with winreg.OpenKey(
+            winreg.HKEY_LOCAL_MACHINE,
+            r"SYSTEM\CurrentControlSet\Control\Session Manager\Environment",
+        ) as key:
+            i = 0
+            while True:
+                try:
+                    name, value, _ = winreg.EnumValue(key, i)
+                    if name.upper() == "PATH":
+                        machine_path = value
+                    else:
+                        env.setdefault(name, value)
+                    i += 1
+                except OSError:
+                    break
+
+        # User-level environment variables
+        user_path = ""
+        try:
+            with winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"Environment") as key:
+                i = 0
+                while True:
+                    try:
+                        name, value, _ = winreg.EnumValue(key, i)
+                        if name.upper() == "PATH":
+                            user_path = value
+                        else:
+                            env.setdefault(name, value)
+                        i += 1
+                    except OSError:
+                        break
+        except OSError:
+            pass
+
+        # PATH: prepend registry paths to ensure system executables are discoverable
+        registry_path = ";".join(filter(None, [machine_path, user_path]))
+        if registry_path:
+            env["PATH"] = ";".join(filter(None, [registry_path, env.get("PATH", "")]))
+
+    except Exception:
+        logger.debug("Failed to read environment from registry")
+        if ".EXE" not in env.get("PATHEXT", ""):
+            env["PATHEXT"] = ".COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC;.CPL;.PY;.PYW"
+
+    # 2) Dynamic variables not stored in registry env keys — only fill if missing
+    if not env.get("COMPUTERNAME"):
+        env["COMPUTERNAME"] = socket.gethostname().upper()
+
+    if not env.get("USERNAME"):
+        try:
+            buf = ctypes.create_unicode_buffer(256)
+            size = ctypes.wintypes.DWORD(256)
+            if ctypes.windll.advapi32.GetUserNameW(buf, ctypes.byref(size)):
+                env["USERNAME"] = buf.value
+        except Exception as e:
+            logger.debug("Failed to get USERNAME via Win32 API: %s", e)
+            pass
+
+    user_profile = os.path.expanduser("~")
+    env.setdefault("USERPROFILE", user_profile)
+    drive, tail = os.path.splitdrive(user_profile)
+    env.setdefault("HOMEDRIVE", drive)
+    env.setdefault("HOMEPATH", tail)
+    env.setdefault("USERDOMAIN", env.get("COMPUTERNAME", ""))
+
+    return env
 
 
 class PowerShellExecutor:
@@ -29,36 +120,11 @@ class PowerShellExecutor:
                 f"{command}"
             )
             encoded = base64.b64encode(utf8_command.encode("utf-16le")).decode("ascii")
-            env = os.environ.copy()
+            env = _prepare_env()
             # NO_COLOR suppresses ANSI escape sequences in pwsh 7.2+ (and many other CLI tools).
             # PS5.1 has no ANSI output, so this is harmlessly ignored there.
             # https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_ansi_terminals#disabling-ansi-output
             env["NO_COLOR"] = "1"
-
-            # Rebuild PATH and PATHEXT from registry so system executables (e.g. OpenSSH at
-            # C:\Windows\System32\OpenSSH) are discoverable without requiring absolute paths.
-            # The inherited env may be stripped down by venv activation or the MCP host.
-            try:
-                import winreg
-
-                with winreg.OpenKey(
-                    winreg.HKEY_LOCAL_MACHINE,
-                    r"SYSTEM\CurrentControlSet\Control\Session Manager\Environment",
-                ) as machine_key:
-                    machine_path = winreg.QueryValueEx(machine_key, "PATH")[0]
-                    if ".EXE" not in env.get("PATHEXT", ""):
-                        env["PATHEXT"] = winreg.QueryValueEx(machine_key, "PATHEXT")[0]
-
-                try:
-                    with winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"Environment") as user_key:
-                        user_path = winreg.QueryValueEx(user_key, "PATH")[0]
-                except FileNotFoundError:
-                    user_path = ""
-
-                env["PATH"] = ";".join(filter(None, [machine_path, user_path, env.get("PATH", "")]))
-            except Exception:
-                if ".EXE" not in env.get("PATHEXT", ""):
-                    env["PATHEXT"] = ".COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC;.CPL;.PY;.PYW"
 
             shell = shell or ("pwsh" if shutil.which("pwsh") else "powershell")
 

--- a/src/windows_mcp/desktop/powershell.py
+++ b/src/windows_mcp/desktop/powershell.py
@@ -34,6 +34,7 @@ def _prepare_env() -> dict[str, str]:
         import winreg
 
         # System-level environment variables
+        machine_pathext = ""
         with winreg.OpenKey(
             winreg.HKEY_LOCAL_MACHINE,
             r"SYSTEM\CurrentControlSet\Control\Session Manager\Environment",
@@ -42,8 +43,11 @@ def _prepare_env() -> dict[str, str]:
             while True:
                 try:
                     name, value, _ = winreg.EnumValue(key, i)
-                    if name.upper() == "PATH":
+                    upper = name.upper()
+                    if upper == "PATH":
                         machine_path = value
+                    elif upper == "PATHEXT":
+                        machine_pathext = value
                     else:
                         env.setdefault(name, value)
                     i += 1
@@ -73,6 +77,10 @@ def _prepare_env() -> dict[str, str]:
         if registry_path:
             env["PATH"] = ";".join(filter(None, [registry_path, env.get("PATH", "")]))
 
+        # PATHEXT: use registry value if the inherited one looks incomplete (e.g. venv strips it)
+        if machine_pathext and ".EXE" not in env.get("PATHEXT", ""):
+            env["PATHEXT"] = machine_pathext
+
     except Exception:
         logger.debug("Failed to read environment from registry")
         if ".EXE" not in env.get("PATHEXT", ""):
@@ -90,7 +98,6 @@ def _prepare_env() -> dict[str, str]:
                 env["USERNAME"] = buf.value
         except Exception as e:
             logger.debug("Failed to get USERNAME via Win32 API: %s", e)
-            pass
 
     user_profile = os.path.expanduser("~")
     env.setdefault("USERPROFILE", user_profile)

--- a/src/windows_mcp/desktop/powershell.py
+++ b/src/windows_mcp/desktop/powershell.py
@@ -76,8 +76,8 @@ def _win32_name(dll: str, func: str) -> str:
     Only suitable for APIs with the (buffer, &size) calling convention,
     e.g. kernel32.GetComputerNameW and advapi32.GetUserNameW.
     """
-    buf = ctypes.create_unicode_buffer(256)
-    size = ctypes.wintypes.DWORD(256)
+    buf = ctypes.create_unicode_buffer(257)
+    size = ctypes.wintypes.DWORD(257)
     fn = getattr(ctypes.windll, dll)
     if getattr(fn, func)(buf, ctypes.byref(size)):
         return buf.value
@@ -112,7 +112,8 @@ def _prepare_env() -> dict[str, str]:
         # Supplement missing vars. User-level (HKCU) takes precedence over
         # system-level (HKLM) for same-named keys, matching Windows' resolution order.
         for name, value in {**machine_vars, **user_vars}.items():
-            env.setdefault(name, value)
+            if not env.get(name):
+                env[name] = value
 
         # PATH: inherited entries keep their priority; registry entries are
         # appended to fill in anything missing (e.g. stripped MCP host env).
@@ -121,12 +122,12 @@ def _prepare_env() -> dict[str, str]:
 
         # PATHEXT: use registry value if the inherited one looks incomplete
         effective_pathext = user_pathext or machine_pathext
-        if effective_pathext and ".EXE" not in env.get("PATHEXT", ""):
+        if effective_pathext and ".EXE" not in env.get("PATHEXT", "").upper():
             env["PATHEXT"] = effective_pathext
 
     except Exception:
-        logger.debug("Failed to read environment from registry")
-        if ".EXE" not in env.get("PATHEXT", ""):
+        logger.debug("Failed to read environment from registry", exc_info=True)
+        if ".EXE" not in env.get("PATHEXT", "").upper():
             env["PATHEXT"] = _FALLBACK_PATHEXT
 
     # Dynamic variables not stored in registry — only fill if missing

--- a/src/windows_mcp/desktop/powershell.py
+++ b/src/windows_mcp/desktop/powershell.py
@@ -5,6 +5,7 @@ import ctypes
 import ctypes.wintypes
 import logging
 import os
+import winreg
 import shutil
 import subprocess
 
@@ -20,8 +21,6 @@ def _read_reg_env(hkey: int, subkey: str) -> tuple[dict[str, str], str, str]:
     (excluding PATH/PATHEXT), and *path*/*pathext* are the raw expanded
     values for those two special keys (empty string if absent).
     """
-    import winreg
-
     variables: dict[str, str] = {}
     path = ""
     pathext = ""
@@ -32,7 +31,16 @@ def _read_reg_env(hkey: int, subkey: str) -> tuple[dict[str, str], str, str]:
             while True:
                 try:
                     name, value, reg_type = winreg.EnumValue(key, i)
+                    if reg_type not in (winreg.REG_SZ, winreg.REG_EXPAND_SZ):
+                        i += 1
+                        continue
                     if reg_type == winreg.REG_EXPAND_SZ:
+                        # Note: ExpandEnvironmentStrings uses the current process
+                        # environment, which may be stripped by the MCP host. References
+                        # to missing vars (e.g. %COMPUTERNAME%) won't expand correctly.
+                        # In practice this is acceptable: most REG_EXPAND_SZ values under
+                        # HKLM/HKCU\Environment reference %SystemRoot% or %USERPROFILE%
+                        # which are almost always present.
                         value = winreg.ExpandEnvironmentStrings(value)
                     upper = name.upper()
                     if upper == "PATH":
@@ -63,7 +71,11 @@ def _dedup_path(*segments: str) -> str:
 
 
 def _win32_name(dll: str, func: str) -> str:
-    """Call a Win32 GetXxxNameW function that writes into a WCHAR buffer."""
+    """Call a Win32 GetXxxNameW(LPWSTR, LPDWORD) function.
+
+    Only suitable for APIs with the (buffer, &size) calling convention,
+    e.g. kernel32.GetComputerNameW and advapi32.GetUserNameW.
+    """
     buf = ctypes.create_unicode_buffer(256)
     size = ctypes.wintypes.DWORD(256)
     fn = getattr(ctypes.windll, dll)
@@ -85,13 +97,12 @@ def _prepare_env() -> dict[str, str]:
       2. User-level env vars from the registry (HKCU)
       3. Dynamic vars (COMPUTERNAME, USERNAME, etc.) via Win32 API
     Existing values in os.environ are never overwritten, only missing ones
-    are supplemented. PATH is special-cased: registry paths are prepended.
+    are supplemented. PATH is special-cased: inherited entries keep their
+    priority and registry entries are appended to fill in missing paths.
     """
     env = os.environ.copy()
 
     try:
-        import winreg
-
         machine_vars, machine_path, machine_pathext = _read_reg_env(
             winreg.HKEY_LOCAL_MACHINE,
             r"SYSTEM\CurrentControlSet\Control\Session Manager\Environment",
@@ -103,9 +114,10 @@ def _prepare_env() -> dict[str, str]:
         for name, value in {**machine_vars, **user_vars}.items():
             env.setdefault(name, value)
 
-        # PATH: prepend registry paths, deduplicated
+        # PATH: inherited entries keep their priority; registry entries are
+        # appended to fill in anything missing (e.g. stripped MCP host env).
         if machine_path or user_path:
-            env["PATH"] = _dedup_path(machine_path, user_path, env.get("PATH", ""))
+            env["PATH"] = _dedup_path(env.get("PATH", ""), machine_path, user_path)
 
         # PATHEXT: use registry value if the inherited one looks incomplete
         effective_pathext = user_pathext or machine_pathext
@@ -139,6 +151,10 @@ def _prepare_env() -> dict[str, str]:
     drive, tail = os.path.splitdrive(user_profile)
     env.setdefault("HOMEDRIVE", drive)
     env.setdefault("HOMEPATH", tail)
+    # On domain-joined machines USERDOMAIN is the NetBIOS domain name (e.g.
+    # "CORP"), not the computer name. This fallback is only correct for workgroup
+    # machines. USERDOMAIN is a session variable set at logon and is unlikely to
+    # be missing on domain-joined hosts, so this is an acceptable last resort.
     env.setdefault("USERDOMAIN", env.get("COMPUTERNAME", ""))
 
     return env


### PR DESCRIPTION
## Summary

When MCP hosts (e.g. Claude Desktop) launch the windows-mcp server, the child process often inherits a stripped environment block. This causes PowerShell commands like `$env:COMPUTERNAME` to return empty strings, silently breaking scripts that depend on session-level variables.

**Closes:** #212

This PR introduces `_prepare_env()`, which reconstructs a complete environment block before spawning PowerShell by:

- **Reading registry env vars** from both HKLM (system) and HKCU (user), with HKCU taking precedence — matching Windows' native resolution order
- **Recovering dynamic variables** (`COMPUTERNAME`, `USERNAME`, `USERPROFILE`, `HOMEDRIVE`, `HOMEPATH`, `USERDOMAIN`) via Win32 API / stdlib when missing
- **Merging PATH intelligently** — inherited entries keep their priority; registry entries are appended to fill gaps, with case-insensitive deduplication
- **Fixing PATHEXT** — restores the registry value when the inherited one looks incomplete (e.g. missing `.EXE`)

Existing values in `os.environ` are never overwritten; only missing ones are supplemented.

## Changes

| File | Change |
|------|--------|
| `src/windows_mcp/desktop/powershell.py` | +150 / -26 |

### Key additions

- `_read_reg_env(hkey, subkey)` — Enumerates a registry key, returns `(vars, path, pathext)`. Filters non-string types (`REG_DWORD`, `REG_BINARY`, etc.) and expands `REG_EXPAND_SZ` values.
- `_dedup_path(*segments)` — Joins and deduplicates PATH entries (case-insensitive, trailing-backslash-normalized).
- `_win32_name(dll, func)` — Calls `GetComputerNameW` / `GetUserNameW` to recover dynamic variables not stored in the registry.
- `_prepare_env()` — Orchestrates the above to produce a complete `env` dict for `subprocess`.

### What was removed

The inline PATH/PATHEXT registry patching inside `PowerShellExecutor.execute_command()` is replaced by the call to `_prepare_env()`.
