### PR TITLE
Revert "feat: add UV path override config for restricted Windows environments"

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,39 +381,6 @@ npm install -g @anthropic-ai/claude-code
 
 ---
 
-
-### Corporate / Restricted Environments
-
-On locked-down Windows machines, security policies such as **AppLocker** or **Software Restriction Policies** may block execution of binaries from user-profile directories (`%APPDATA%`, `%LOCALAPPDATA%`). Since UV stores its cache, managed Python interpreters, and virtual environments under these paths by default, Windows-MCP will fail to start.
-
-To work around this, configure the three UV path overrides in your MCP client settings to point to a directory outside the user profile (e.g., `C:\dev\.uv`):
-
-| Setting | Example value | UV docs |
-|---|---|---|
-| `uv_cache_dir` | `C:/dev/.uv/cache` | [UV_CACHE_DIR](https://docs.astral.sh/uv/reference/environment/#uv_cache_dir) |
-| `uv_python_install_dir` | `C:/dev/.uv/python` | [UV_PYTHON_INSTALL_DIR](https://docs.astral.sh/uv/reference/environment/#uv_python_install_dir) |
-| `uv_project_environment` | `C:/dev/.uv/venvs/windows-mcp` | [UV_PROJECT_ENVIRONMENT](https://docs.astral.sh/uv/reference/environment/#uv_project_environment) |
-
-If you are configuring Windows-MCP manually via `claude_desktop_config.json` (or equivalent), add these as environment variables:
-
-```json
-{
-  "mcpServers": {
-    "windows-mcp": {
-      "command": "uvx",
-      "args": ["windows-mcp"],
-      "env": {
-        "UV_CACHE_DIR": "C:/dev/.uv/cache",
-        "UV_PYTHON_INSTALL_DIR": "C:/dev/.uv/python",
-        "UV_PROJECT_ENVIRONMENT": "C:/dev/.uv/venvs/windows-mcp"
-      }
-    }
-  }
-}
-```
-
-The target directories must exist and be writable. These settings have no effect when left unset; UV will use its built-in defaults.
-
 ## 🖥️ Modes
 
 Windows-MCP supports two operating modes: **Local** (default) and **Remote**.

--- a/manifest.json
+++ b/manifest.json
@@ -34,10 +34,7 @@
         "API_KEY": "${user_config.api_key}",
         "WINDOWS_MCP_PROFILE_SNAPSHOT": "${user_config.profile_snapshot}",
         "WINDOWS_MCP_SCREENSHOT_BACKEND": "${user_config.screenshot_backend}",
-        "WINDOWS_MCP_DEBUG": "${user_config.debug}",
-        "UV_CACHE_DIR": "${user_config.uv_cache_dir}",
-        "UV_PYTHON_INSTALL_DIR": "${user_config.uv_python_install_dir}",
-        "UV_PROJECT_ENVIRONMENT": "${user_config.uv_project_environment}"
+        "WINDOWS_MCP_DEBUG": "${user_config.debug}"
       }
     }
   },
@@ -88,24 +85,6 @@
       "description": "Enable debug mode to provide verbose logging for troubleshooting.",
       "required": false,
       "default": false
-    },
-    "uv_cache_dir": {
-      "type": "string",
-      "title": "UV Cache Directory",
-      "description": "Override where UV stores downloaded packages and build artifacts. Useful when system policies (e.g., AppLocker) block running executables from the user profile directory. Leave unset to use UV's default. Docs: https://docs.astral.sh/uv/reference/environment/#uv_cache_dir",
-      "required": false
-    },
-    "uv_python_install_dir": {
-      "type": "string",
-      "title": "UV Python Install Directory",
-      "description": "Override where UV installs managed Python interpreters. Useful when system policies block running executables from the user profile directory. Leave unset to use UV's default. Docs: https://docs.astral.sh/uv/reference/environment/#uv_python_install_dir",
-      "required": false
-    },
-    "uv_project_environment": {
-      "type": "string",
-      "title": "UV Project Virtual Environment",
-      "description": "Override where UV creates this project's virtual environment instead of the default .venv directory. Useful when system policies block running executables from the user profile directory. Leave unset to use UV's default. Docs: https://docs.astral.sh/uv/reference/environment/#uv_project_environment",
-      "required": false
     }
   },
   "tools": [


### PR DESCRIPTION
Reverts CursorTouch/Windows-MCP#199.

See https://github.com/CursorTouch/Windows-MCP/pull/199#issuecomment-4282480516