### PR TITLE
fix: Add setuptools as an extra build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,3 +75,5 @@ ignore = ["E501"]
 testpaths = ["tests"]
 asyncio_mode = "auto"
 
+[tool.uv.extra-build-dependencies]
+pyperclip = ["setuptools"]


### PR DESCRIPTION
My system has a _uv.toml_ in the root: with `no-build-isolation = true`
So installing as a **Claude for Windows** extension fails with:

```console
2026-04-24T15:03:21.893Z [Windows-MCP] [info] Server started and connected successfully { metadata: undefined }
2026-04-24T15:03:22.005Z [Windows-MCP] [info] Message from client: {"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{"extensions":{"io.modelcontextprotocol/ui":{"mimeTypes":["text/html;profile=mcp-app"]}}},"clientInfo":{"name":"claude-ai","version":"0.1.0"}},"jsonrpc":"2.0","id":0} { metadata: undefined }
Using CPython 3.13.11
Creating virtual environment at: .venv
Resolving despite existing lockfile due to change in pre-release mode: `if-necessary-or-explicit` vs. `allow`
  × Failed to build `pyperclip==1.9.0`
  ├─▶ The build backend returned an error
  ╰─▶ Call to
      `setuptools.build_meta:__legacy__.prepare_metadata_for_build_wheel`
      failed (exit code: 1)

      [stderr]
      Traceback (most recent call last):
        File "<string>", line 8, in <module>
          from setuptools.build_meta import __legacy__ as backend
      ModuleNotFoundError: No module named 'setuptools'

      hint: This error likely indicates that `pyperclip@1.9.0` depends
      on `setuptools`, but doesn't declare it as a build dependency. If
      `pyperclip` is a first-party package, consider adding `setuptools`
      to its `build-system.requires`. Otherwise, either add it to your
      `pyproject.toml` under:

      [tool.uv.extra-build-dependencies]
      pyperclip = ["setuptools"]

      or `uv pip install setuptools` into the environment and re-run with
      `--no-build-isolation`.
  help: `pyperclip` (v1.9.0) was included because `windows-mcp` (v0.7.1)
        depends on `fastmcp>=3.0` (v3.2.0) which depends on `pyperclip>=1.9.0`
2026-04-24T15:03:22.949Z [Windows-MCP] [info] Server transport closed { metadata: undefined }
2026-04-24T15:03:22.949Z [Windows-MCP] [info] Client transport closed { metadata: undefined }
2026-04-24T15:03:22.950Z [Windows-MCP] [info] Server transport closed unexpectedly, this is likely due to the process exiting early. If you are developing this MCP server you can add output to stderr (i.e. `console.error('...')` in JavaScript, `print('...', file=sys.stderr)` in python) and it will appear in this log. { metadata: undefined }
2026-04-24T15:03:22.950Z [Windows-MCP] [error] Server disconnected. For troubleshooting guidance, please visit our [debugging documentation](https://modelcontextprotocol.io/docs/tools/debugging) { metadata: { context: 'connection', stack: undefined } }
2026-04-24T15:03:22.950Z [Windows-MCP] [info] Client transport closed { metadata: undefined }
```