### PR TITLE
refactor: extract registry logic into a dedicated module

### DIFF
--- a/src/windows_mcp/desktop/service.py
+++ b/src/windows_mcp/desktop/service.py
@@ -1420,67 +1420,6 @@ class Desktop:
             return f'No process matching "{name}" found or access denied.'
         return f"{'Force killed' if force else 'Terminated'}: {', '.join(killed)}"
 
-
-
-
-
-    def registry_get(self, path: str, name: str) -> str:
-        q_path = ps_quote(path)
-        q_name = ps_quote(name)
-        command = f"Get-ItemProperty -Path {q_path} -Name {q_name} | Select-Object -ExpandProperty {q_name}"
-        response, status = PowerShellExecutor.execute_command(command)
-        if status != 0:
-            return f'Error reading registry: {response.strip()}'
-        return f'Registry value [{path}] "{name}" = {response.strip()}'
-
-    def registry_set(self, path: str, name: str, value: str, reg_type: str = 'String') -> str:
-        q_path = ps_quote(path)
-        q_name = ps_quote(name)
-        q_value = ps_quote(value)
-        allowed_types = {"String", "ExpandString", "Binary", "DWord", "MultiString", "QWord"}
-        if reg_type not in allowed_types:
-            return f"Error: invalid registry type '{reg_type}'. Allowed: {', '.join(sorted(allowed_types))}"
-        command = (
-            f"if (-not (Test-Path {q_path})) {{ New-Item -Path {q_path} -Force | Out-Null }}; "
-            f"Set-ItemProperty -Path {q_path} -Name {q_name} -Value {q_value} -Type {reg_type} -Force"
-        )
-        response, status = PowerShellExecutor.execute_command(command)
-        if status != 0:
-            return f'Error writing registry: {response.strip()}'
-        return f'Registry value [{path}] "{name}" set to "{value}" (type: {reg_type}).'
-
-    def registry_delete(self, path: str, name: str | None = None) -> str:
-        q_path = ps_quote(path)
-        if name:
-            q_name = ps_quote(name)
-            command = f"Remove-ItemProperty -Path {q_path} -Name {q_name} -Force"
-            response, status = PowerShellExecutor.execute_command(command)
-            if status != 0:
-                return f'Error deleting registry value: {response.strip()}'
-            return f'Registry value [{path}] "{name}" deleted.'
-        else:
-            command = f"Remove-Item -Path {q_path} -Recurse -Force"
-            response, status = PowerShellExecutor.execute_command(command)
-            if status != 0:
-                return f'Error deleting registry key: {response.strip()}'
-            return f'Registry key [{path}] deleted.'
-
-    def registry_list(self, path: str) -> str:
-        q_path = ps_quote(path)
-        command = (
-            f"$values = (Get-ItemProperty -Path {q_path} -ErrorAction Stop | "
-            f"Select-Object * -ExcludeProperty PS* | Format-List | Out-String).Trim(); "
-            f"$subkeys = (Get-ChildItem -Path {q_path} -ErrorAction SilentlyContinue | "
-            f"Select-Object -ExpandProperty PSChildName) -join \"`n\"; "
-            f"if ($values) {{ Write-Output \"Values:`n$values\" }}; "
-            f"if ($subkeys) {{ Write-Output \"`nSub-Keys:`n$subkeys\" }}; "
-            f"if (-not $values -and -not $subkeys) {{ Write-Output 'No values or sub-keys found.' }}"
-        )
-        response, status = PowerShellExecutor.execute_command(command)
-        if status != 0:
-            return f'Error listing registry: {response.strip()}'
-        return f'Registry key [{path}]:\n{response.strip()}'
-
     @contextmanager
     def auto_minimize(self):
         try:

--- a/src/windows_mcp/registry/__init__.py
+++ b/src/windows_mcp/registry/__init__.py
@@ -1,0 +1,11 @@
+from windows_mcp.registry.service import (
+    get_value,
+    set_value,
+    delete_entry,
+    list_key,
+)
+
+from windows_mcp.registry.views import (
+    ALLOWED_REGISTRY_TYPES,
+    RegistryType,
+)

--- a/src/windows_mcp/registry/service.py
+++ b/src/windows_mcp/registry/service.py
@@ -1,0 +1,83 @@
+"""
+Registry service for the Windows MCP server.
+Provides structured operations for reading and writing the Windows Registry
+via PowerShell cmdlets.
+"""
+
+import logging
+
+from windows_mcp.desktop.powershell import PowerShellExecutor
+from windows_mcp.desktop.utils import ps_quote
+from windows_mcp.registry.views import ALLOWED_REGISTRY_TYPES, RegistryType
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+def get_value(path: str, name: str) -> str:
+    """Read a registry value at *path* with the given *name*."""
+    q_path = ps_quote(path)
+    q_name = ps_quote(name)
+    command = (
+        f"Get-ItemProperty -Path {q_path} -Name {q_name} | "
+        f"Select-Object -ExpandProperty {q_name}"
+    )
+    response, status = PowerShellExecutor.execute_command(command)
+    if status != 0:
+        return f'Error reading registry: {response.strip()}'
+    return f'Registry value [{path}] "{name}" = {response.strip()}'
+
+
+def set_value(path: str, name: str, value: str, reg_type: RegistryType = 'String') -> str:
+    """Create or update a registry value, creating the key if it does not exist."""
+    if reg_type not in ALLOWED_REGISTRY_TYPES:
+        return (
+            f"Error: invalid registry type '{reg_type}'. "
+            f"Allowed: {', '.join(sorted(ALLOWED_REGISTRY_TYPES))}"
+        )
+    q_path = ps_quote(path)
+    q_name = ps_quote(name)
+    q_value = ps_quote(value)
+    command = (
+        f"if (-not (Test-Path {q_path})) {{ New-Item -Path {q_path} -Force | Out-Null }}; "
+        f"Set-ItemProperty -Path {q_path} -Name {q_name} -Value {q_value} -Type {reg_type} -Force"
+    )
+    response, status = PowerShellExecutor.execute_command(command)
+    if status != 0:
+        return f'Error writing registry: {response.strip()}'
+    return f'Registry value [{path}] "{name}" set to "{value}" (type: {reg_type}).'
+
+
+def delete_entry(path: str, name: str | None = None) -> str:
+    """Delete a registry value when *name* is provided, otherwise remove the entire key."""
+    q_path = ps_quote(path)
+    if name:
+        q_name = ps_quote(name)
+        command = f"Remove-ItemProperty -Path {q_path} -Name {q_name} -Force"
+        response, status = PowerShellExecutor.execute_command(command)
+        if status != 0:
+            return f'Error deleting registry value: {response.strip()}'
+        return f'Registry value [{path}] "{name}" deleted.'
+    command = f"Remove-Item -Path {q_path} -Recurse -Force"
+    response, status = PowerShellExecutor.execute_command(command)
+    if status != 0:
+        return f'Error deleting registry key: {response.strip()}'
+    return f'Registry key [{path}] deleted.'
+
+
+def list_key(path: str) -> str:
+    """List values and sub-keys under *path*."""
+    q_path = ps_quote(path)
+    command = (
+        f"$values = (Get-ItemProperty -Path {q_path} -ErrorAction Stop | "
+        f"Select-Object * -ExcludeProperty PS* | Format-List | Out-String).Trim(); "
+        f"$subkeys = (Get-ChildItem -Path {q_path} -ErrorAction SilentlyContinue | "
+        f"Select-Object -ExpandProperty PSChildName) -join \"`n\"; "
+        f"if ($values) {{ Write-Output \"Values:`n$values\" }}; "
+        f"if ($subkeys) {{ Write-Output \"`nSub-Keys:`n$subkeys\" }}; "
+        f"if (-not $values -and -not $subkeys) {{ Write-Output 'No values or sub-keys found.' }}"
+    )
+    response, status = PowerShellExecutor.execute_command(command)
+    if status != 0:
+        return f'Error listing registry: {response.strip()}'
+    return f'Registry key [{path}]:\n{response.strip()}'

--- a/src/windows_mcp/registry/views.py
+++ b/src/windows_mcp/registry/views.py
@@ -1,0 +1,26 @@
+"""
+Data models and constants for registry operations.
+"""
+
+from typing import Literal
+
+# Registry value types accepted by Set-ItemProperty -Type.
+ALLOWED_REGISTRY_TYPES = frozenset(
+    {
+        "String",
+        "ExpandString",
+        "Binary",
+        "DWord",
+        "MultiString",
+        "QWord",
+    }
+)
+
+RegistryType = Literal[
+    "String",
+    "ExpandString",
+    "Binary",
+    "DWord",
+    "MultiString",
+    "QWord",
+]

--- a/src/windows_mcp/tools/registry.py
+++ b/src/windows_mcp/tools/registry.py
@@ -4,6 +4,8 @@ from typing import Literal
 
 from mcp.types import ToolAnnotations
 from windows_mcp.analytics import with_analytics
+from windows_mcp import registry
+from windows_mcp.registry import RegistryType
 from fastmcp import Context
 
 
@@ -25,25 +27,24 @@ def register(mcp, *, get_desktop, get_analytics):
         path: str,
         name: str | None = None,
         value: str | None = None,
-        type: Literal['String', 'DWord', 'QWord', 'Binary', 'MultiString', 'ExpandString'] = 'String',
+        type: RegistryType = 'String',
         ctx: Context = None,
     ) -> str:
-        desktop = get_desktop()
         try:
             if mode == 'get':
                 if name is None:
                     return 'Error: name parameter is required for get mode.'
-                return desktop.registry_get(path=path, name=name)
+                return registry.get_value(path=path, name=name)
             elif mode == 'set':
                 if name is None:
                     return 'Error: name parameter is required for set mode.'
                 if value is None:
                     return 'Error: value parameter is required for set mode.'
-                return desktop.registry_set(path=path, name=name, value=value, reg_type=type)
+                return registry.set_value(path=path, name=name, value=value, reg_type=type)
             elif mode == 'delete':
-                return desktop.registry_delete(path=path, name=name)
+                return registry.delete_entry(path=path, name=name)
             elif mode == 'list':
-                return desktop.registry_list(path=path)
+                return registry.list_key(path=path)
             else:
                 return 'Error: mode must be "get", "set", "delete", or "list".'
         except Exception as e:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,19 +1,10 @@
 from unittest.mock import patch
 
-import pytest
-
-from windows_mcp.desktop.service import Desktop
+from windows_mcp import registry
 from windows_mcp.desktop.utils import ps_quote
 
 
 EXECUTE_COMMAND_PATH = "windows_mcp.desktop.powershell.PowerShellExecutor.execute_command"
-
-
-@pytest.fixture
-def desktop():
-    with patch.object(Desktop, '__init__', lambda self: None):
-        d = Desktop()
-        return d
 
 
 class TestPsQuote:
@@ -38,103 +29,103 @@ class TestPsQuote:
 
 
 class TestRegistryGet:
-    def test_success(self, desktop):
+    def test_success(self):
         with patch(EXECUTE_COMMAND_PATH, return_value=("42\n", 0)):
-            result = desktop.registry_get(path="HKCU:\\Software\\Test", name="MyValue")
+            result = registry.get_value(path="HKCU:\\Software\\Test", name="MyValue")
         assert 'MyValue' in result
         assert '42' in result
         assert 'Error' not in result
 
-    def test_failure(self, desktop):
+    def test_failure(self):
         with patch(EXECUTE_COMMAND_PATH, return_value=("Property not found", 1)):
-            result = desktop.registry_get(path="HKCU:\\Software\\Test", name="Missing")
+            result = registry.get_value(path="HKCU:\\Software\\Test", name="Missing")
         assert 'Error reading registry' in result
         assert 'Property not found' in result
 
-    def test_command_uses_ps_quote(self, desktop):
+    def test_command_uses_ps_quote(self):
         with patch(EXECUTE_COMMAND_PATH, return_value=("val", 0)) as mock_exec:
-            desktop.registry_get(path="HKCU:\\Software\\O'Reilly", name="key's")
+            registry.get_value(path="HKCU:\\Software\\O'Reilly", name="key's")
         cmd = mock_exec.call_args[0][0]
         assert "HKCU:\\Software\\O''Reilly" in cmd
         assert "key''s" in cmd
 
 
 class TestRegistrySet:
-    def test_success(self, desktop):
+    def test_success(self):
         with patch(EXECUTE_COMMAND_PATH, return_value=("", 0)):
-            result = desktop.registry_set(path="HKCU:\\Software\\Test", name="MyKey", value="hello")
+            result = registry.set_value(path="HKCU:\\Software\\Test", name="MyKey", value="hello")
         assert 'set to' in result
         assert '"hello"' in result
 
-    def test_failure(self, desktop):
+    def test_failure(self):
         with patch(EXECUTE_COMMAND_PATH, return_value=("Access denied", 1)):
-            result = desktop.registry_set(path="HKLM:\\Software\\Test", name="Key", value="val")
+            result = registry.set_value(path="HKLM:\\Software\\Test", name="Key", value="val")
         assert 'Error writing registry' in result
 
-    def test_invalid_type(self, desktop):
+    def test_invalid_type(self):
         with patch(EXECUTE_COMMAND_PATH) as mock_exec:
-            result = desktop.registry_set(path="HKCU:\\Test", name="Key", value="val", reg_type="Invalid")
+            result = registry.set_value(path="HKCU:\\Test", name="Key", value="val", reg_type="Invalid")
         assert 'Error: invalid registry type' in result
         assert 'Invalid' in result
         mock_exec.assert_not_called()
 
-    def test_all_valid_types(self, desktop):
+    def test_all_valid_types(self):
         with patch(EXECUTE_COMMAND_PATH, return_value=("", 0)):
             for reg_type in ("String", "ExpandString", "Binary", "DWord", "MultiString", "QWord"):
-                result = desktop.registry_set(path="HKCU:\\Test", name="K", value="V", reg_type=reg_type)
+                result = registry.set_value(path="HKCU:\\Test", name="K", value="V", reg_type=reg_type)
                 assert 'Error' not in result
 
-    def test_creates_key_if_missing(self, desktop):
+    def test_creates_key_if_missing(self):
         with patch(EXECUTE_COMMAND_PATH, return_value=("", 0)) as mock_exec:
-            desktop.registry_set(path="HKCU:\\Software\\NewKey", name="Val", value="1")
+            registry.set_value(path="HKCU:\\Software\\NewKey", name="Val", value="1")
         cmd = mock_exec.call_args[0][0]
         assert "New-Item" in cmd
         assert "Test-Path" in cmd
 
 
 class TestRegistryDelete:
-    def test_delete_value(self, desktop):
+    def test_delete_value(self):
         with patch(EXECUTE_COMMAND_PATH, return_value=("", 0)) as mock_exec:
-            result = desktop.registry_delete(path="HKCU:\\Software\\Test", name="MyValue")
+            result = registry.delete_entry(path="HKCU:\\Software\\Test", name="MyValue")
         assert 'deleted' in result
         assert '"MyValue"' in result
         cmd = mock_exec.call_args[0][0]
         assert "Remove-ItemProperty" in cmd
 
-    def test_delete_key(self, desktop):
+    def test_delete_key(self):
         with patch(EXECUTE_COMMAND_PATH, return_value=("", 0)) as mock_exec:
-            result = desktop.registry_delete(path="HKCU:\\Software\\Test", name=None)
+            result = registry.delete_entry(path="HKCU:\\Software\\Test", name=None)
         assert 'key' in result.lower()
         assert 'deleted' in result
         cmd = mock_exec.call_args[0][0]
         assert "Remove-Item" in cmd
         assert "-Recurse" in cmd
 
-    def test_delete_value_failure(self, desktop):
+    def test_delete_value_failure(self):
         with patch(EXECUTE_COMMAND_PATH, return_value=("Not found", 1)):
-            result = desktop.registry_delete(path="HKCU:\\Software\\Test", name="Missing")
+            result = registry.delete_entry(path="HKCU:\\Software\\Test", name="Missing")
         assert 'Error deleting registry value' in result
 
-    def test_delete_key_failure(self, desktop):
+    def test_delete_key_failure(self):
         with patch(EXECUTE_COMMAND_PATH, return_value=("Access denied", 1)):
-            result = desktop.registry_delete(path="HKCU:\\Software\\Protected")
+            result = registry.delete_entry(path="HKCU:\\Software\\Protected")
         assert 'Error deleting registry key' in result
 
 
 class TestRegistryList:
-    def test_success(self, desktop):
+    def test_success(self):
         with patch(EXECUTE_COMMAND_PATH, return_value=("Values:\nMyKey : hello\n\nSub-Keys:\nChild1", 0)):
-            result = desktop.registry_list(path="HKCU:\\Software\\Test")
+            result = registry.list_key(path="HKCU:\\Software\\Test")
         assert 'MyKey' in result
         assert 'hello' in result
         assert 'Child1' in result
 
-    def test_failure(self, desktop):
+    def test_failure(self):
         with patch(EXECUTE_COMMAND_PATH, return_value=("Path not found", 1)):
-            result = desktop.registry_list(path="HKCU:\\Software\\Missing")
+            result = registry.list_key(path="HKCU:\\Software\\Missing")
         assert 'Error listing registry' in result
 
-    def test_empty(self, desktop):
+    def test_empty(self):
         with patch(EXECUTE_COMMAND_PATH, return_value=("No values or sub-keys found.", 0)):
-            result = desktop.registry_list(path="HKCU:\\Software\\Empty")
+            result = registry.list_key(path="HKCU:\\Software\\Empty")
         assert 'No values or sub-keys found' in result


### PR DESCRIPTION
# refactor: extract registry logic into a dedicated module

## Summary

Move the four `Desktop.registry_*` methods into a new `windows_mcp.registry` package, mirroring the layout of `windows_mcp.filesystem`. The `Registry` MCP tool now calls the module directly. Pure structural refactor — no behavior change intended.

## Changes

- **New** `src/windows_mcp/registry/` — `service.py` (`get_value`, `set_value`, `delete_entry`, `list_key`), `views.py` (`ALLOWED_REGISTRY_TYPES`, `RegistryType`), `__init__.py` re-exports.
- **`desktop/service.py`** — removed the four `registry_*` methods (~60 lines).
- **`tools/registry.py`** — calls `windows_mcp.registry.*` directly; uses the shared `RegistryType` alias. Public parameter name `type` is preserved so the MCP JSON-Schema contract is unchanged.
- **`tests/test_registry.py`** — exercises the module functions directly. 

