### PR TITLE
feat: add --stateless-http flag for streamable-http transport

### DIFF
--- a/src/windows_mcp/__main__.py
+++ b/src/windows_mcp/__main__.py
@@ -242,6 +242,7 @@ def _run_server(
     oauth_validator=None,
     cors_origins: list[str] | None = None,
     allowed_hosts: list[str] | None = None,
+    stateless_http: bool = False,
 ) -> None:
     mcp = _build_mcp()
     if explicit_tools or exclude_tools:
@@ -267,6 +268,7 @@ def _run_server(
                     allowed_hosts=allowed_hosts,
                 ),
                 uvicorn_config=uvicorn_config or None,
+                stateless_http=stateless_http,
             )
         case _:
             raise ValueError(f"Invalid transport: {transport}")
@@ -394,7 +396,15 @@ def main():
     type=str,
     show_default=False,
 )
-def serve(ctx, transport, host, port, debug, config, auth_key, allow_insecure_remote, ip_allowlist, tools, exclude_tools, cors_origins, ssl_certfile, ssl_keyfile, oauth_client_id, oauth_client_secret):
+@click.option(
+    "--stateless-http",
+    help="Run the streamable-http transport in stateless mode (no Mcp-Session-Id header). Lets reconnecting clients survive a server restart without re-handshaking, and removes the per-connection state that prevents horizontal scaling. Has no effect on stdio/sse transports.",
+    is_flag=True,
+    default=False,
+    envvar="WINDOWS_MCP_STATELESS_HTTP",
+    show_default=True,
+)
+def serve(ctx, transport, host, port, debug, config, auth_key, allow_insecure_remote, ip_allowlist, tools, exclude_tools, cors_origins, ssl_certfile, ssl_keyfile, oauth_client_id, oauth_client_secret, stateless_http):
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
     if transport == Transport.STDIO.value:
         os.environ.setdefault("NO_COLOR", "1")
@@ -415,6 +425,9 @@ def serve(ctx, transport, host, port, debug, config, auth_key, allow_insecure_re
     host = _choose_value(ctx, "host", host, cfg.server.host, "localhost")
     port = int(_choose_value(ctx, "port", port, cfg.server.port, 8000))
     auth_key = _choose_value(ctx, "auth_key", auth_key, cfg.server.auth_key, None)
+    stateless_http = bool(
+        _choose_value(ctx, "stateless_http", stateless_http, cfg.server.stateless_http, False)
+    )
     allow_insecure_remote = bool(
         _choose_value(ctx, "allow_insecure_remote", allow_insecure_remote, cfg.server.allow_insecure_remote, False)
     )
@@ -517,6 +530,7 @@ def serve(ctx, transport, host, port, debug, config, auth_key, allow_insecure_re
             oauth_validator=oauth_validator,
             cors_origins=cli_cors or None,
             allowed_hosts=computed_allowed_hosts,
+            stateless_http=stateless_http,
         )
         logger.debug("Server shut down normally")
     except Exception:

--- a/src/windows_mcp/infrastructure/config.py
+++ b/src/windows_mcp/infrastructure/config.py
@@ -16,6 +16,13 @@ class ServerConfig:
     auth_key: str | None = None
     ssl_certfile: str | None = None
     ssl_keyfile: str | None = None
+    # When True (and transport is streamable-http) FastMCP is run with
+    # stateless_http=True: no Mcp-Session-Id header is issued and the
+    # server does not maintain per-connection session state. Useful for
+    # resilience against server restarts (a reconnecting client is not
+    # rejected with "Session not found") and for horizontal scaling
+    # behind a load balancer.
+    stateless_http: bool = False
 
 
 @dataclass
@@ -107,6 +114,10 @@ def load_config(path: Path | None) -> WindowsMCPConfig:
         raw = str(server["ssl_keyfile"]) or None
         if raw:
             cfg.server.ssl_keyfile = str((path.parent / raw).resolve())
+    if "stateless_http" in server:
+        cfg.server.stateless_http = _strict_bool(
+            server["stateless_http"], "server.stateless_http"
+        )
 
     if "ip_allowlist" in security:
         cfg.security.ip_allowlist = _list_of_strings(security["ip_allowlist"], "security.ip_allowlist")
@@ -144,6 +155,8 @@ def write_config(cfg: WindowsMCPConfig, path: Path) -> None:
         server_lines.append(f'ssl_certfile = "{sd.ssl_certfile}"')
     if sd.ssl_keyfile:
         server_lines.append(f'ssl_keyfile = "{sd.ssl_keyfile}"')
+    if sd.stateless_http:
+        server_lines.append('stateless_http = true')
     if server_lines:
         lines += ['[server]'] + server_lines + ['']
 

--- a/tests/test_config_stateless.py
+++ b/tests/test_config_stateless.py
@@ -1,0 +1,132 @@
+"""Tests for the server.stateless_http config knob added alongside the
+new --stateless-http CLI flag.
+
+The flag exists so a streamable-http MCP server can be restarted (e.g.
+the host machine reboots, or a horizontal-scaler replaces the pod)
+without rejecting reconnecting clients with "Session not found". When
+the knob is on, FastMCP is run with stateless_http=True so no
+Mcp-Session-Id header is issued and the server keeps no per-connection
+state.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from windows_mcp.infrastructure.config import (
+    ServerConfig,
+    WindowsMCPConfig,
+    load_config,
+    write_config,
+)
+
+
+def test_default_is_false():
+    cfg = ServerConfig()
+    assert cfg.stateless_http is False
+
+
+def test_load_stateless_http_true(tmp_path: Path):
+    p = tmp_path / "config.toml"
+    p.write_text(
+        '[server]\n'
+        'transport = "streamable-http"\n'
+        'stateless_http = true\n',
+        encoding="utf-8",
+    )
+    cfg = load_config(p)
+    assert cfg.server.stateless_http is True
+    assert cfg.server.transport == "streamable-http"
+
+
+def test_load_stateless_http_false_explicit(tmp_path: Path):
+    p = tmp_path / "config.toml"
+    p.write_text(
+        '[server]\n'
+        'stateless_http = false\n',
+        encoding="utf-8",
+    )
+    cfg = load_config(p)
+    assert cfg.server.stateless_http is False
+
+
+def test_load_stateless_http_rejects_non_bool(tmp_path: Path):
+    p = tmp_path / "config.toml"
+    p.write_text(
+        '[server]\n'
+        'stateless_http = "yes"\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="server.stateless_http"):
+        load_config(p)
+
+
+def test_write_config_emits_stateless_http_when_set(tmp_path: Path):
+    cfg = WindowsMCPConfig()
+    cfg.server.stateless_http = True
+    out = tmp_path / "out.toml"
+    write_config(cfg, out)
+    text = out.read_text(encoding="utf-8")
+    assert "stateless_http = true" in text
+
+
+def test_write_config_omits_stateless_http_when_default(tmp_path: Path):
+    cfg = WindowsMCPConfig()
+    # Tweak a non-default value so [server] section is emitted at all,
+    # then verify stateless_http stays absent.
+    cfg.server.transport = "streamable-http"
+    out = tmp_path / "out.toml"
+    write_config(cfg, out)
+    text = out.read_text(encoding="utf-8")
+    assert "stateless_http" not in text
+
+
+def test_load_stateless_http_default_when_absent(tmp_path: Path):
+    p = tmp_path / "config.toml"
+    p.write_text('[server]\nhost = "localhost"\n', encoding="utf-8")
+    cfg = load_config(p)
+    assert cfg.server.stateless_http is False
+
+
+def test_run_server_passes_stateless_http_kwarg(monkeypatch):
+    """When _run_server is called for streamable-http it must forward
+    stateless_http through to FastMCP's mcp.run()."""
+    from windows_mcp import __main__ as wm
+
+    captured: dict = {}
+
+    class _FakeMCP:
+        def run(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(wm, "_build_mcp", lambda: _FakeMCP())
+    monkeypatch.setattr(wm, "_apply_tool_filter", lambda *a, **k: None)
+
+    wm._run_server(
+        transport="streamable-http",
+        host="127.0.0.1",
+        port=8765,
+        stateless_http=True,
+    )
+    assert captured.get("stateless_http") is True
+    assert captured.get("transport") == "streamable-http"
+
+
+def test_run_server_stateless_default_false(monkeypatch):
+    from windows_mcp import __main__ as wm
+
+    captured: dict = {}
+
+    class _FakeMCP:
+        def run(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(wm, "_build_mcp", lambda: _FakeMCP())
+    monkeypatch.setattr(wm, "_apply_tool_filter", lambda *a, **k: None)
+
+    wm._run_server(
+        transport="streamable-http",
+        host="127.0.0.1",
+        port=8765,
+    )
+    assert captured.get("stateless_http") is False


### PR DESCRIPTION
## Summary

Adds opt-in **`--stateless-http`** flag (plus `WINDOWS_MCP_STATELESS_HTTP` env var and `[server] stateless_http` config key) to expose FastMCP's existing `stateless_http=True` mode for the streamable-http transport.

Default stays `False` — current behaviour is preserved.

## Motivation

The default streamable-http transport issues an `Mcp-Session-Id` header on `initialize` and keeps every connection's state in process memory. Two consequences:

1. **Server restart breaks reconnecting clients.** When the host machine reboots / the container rotates / the Scheduled Task respawns, the new server process has no record of the old session id and rejects every cached client with `Session not found` until the client does a full re-handshake. For desktops/laptops that legitimately reboot daily, that means a manual reconnect cycle every time.
2. **No horizontal scaling.** A request that lands on a different replica than the one that issued the session id is rejected, so deployments behind a load balancer are limited to one instance.

FastMCP already supports `stateless_http=True` ([docs](https://gofastmcp.com/deployment/http)) — this PR just wires it through windows-mcp.

## Surface

| Path | Effect |
|---|---|
| CLI `--stateless-http` | Boolean flag on `serve` (default False) |
| Env `WINDOWS_MCP_STATELESS_HTTP` | Same value via env (consistent with other flags) |
| Config `[server] stateless_http = true` | TOML config support, same precedence as the rest |

Stateless mode is a no-op for stdio (no transport sessions) and sse (separate session lifecycle); the flag only applies when transport is streamable-http.

## Implementation

- `ServerConfig` gains `stateless_http: bool = False`
- `load_config` / `write_config` parse and serialize the field (with strict bool validation)
- `serve` adds the click option and threads the value through `_choose_value` so CLI > config > default precedence stays consistent
- `_run_server` accepts `stateless_http: bool = False` and forwards it to `mcp.run(stateless_http=...)` when transport is streamable-http

## Tests

`tests/test_config_stateless.py` covers:
- default value False
- TOML round-trip (load valid, write back, omit when default)
- type validation (non-bool rejected with clear error)
- `_run_server` forwards the kwarg to `mcp.run()` (with `monkeypatch` fakes for `_build_mcp` and `_apply_tool_filter`)

## Verification

Tested end-to-end on a Windows 11 host running windows-mcp 0.7.5 behind a Scheduled Task with `--stateless-http`:

- `curl /mcp` initialize returns **no `mcp-session-id` response header** (was present without the flag)
- FastMCP startup log reports `transport='streamable-http (stateless)'`
- After killing and re-launching the server process while an MCP client still had the old session id cached, the next client request **succeeded against the fresh server with zero re-handshake work** (previously this returned `Session not found`)

## Notes

- Default unchanged, no migration needed.
- Local pytest run requires the full Windows-side dep set (pywin32, fastmcp, starlette); syntax verified on macOS but full test pass is from upstream's Windows environment.