### PR TITLE
feat: add IAccessible2 / MSAA fallback for Firefox DOM extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ mcp-name: io.github.CursorTouch/Windows-MCP
   Typical latency between actions (e.g., from one mouse click to the next) ranges from **0.2 to 0.5 secs**, and may slightly vary based on the number of active applications and system load, also the inferencing speed of the llm.
 
 - **DOM Mode for Browser Automation**  
-  Special `use_dom=True` mode for State-Tool that focuses exclusively on web page content, filtering out browser UI elements for cleaner, more efficient web automation.
+  Special `use_dom=True` mode for State-Tool that focuses exclusively on web page content, filtering out browser UI elements for cleaner, more efficient web automation. Supports Chrome, Edge, and Firefox (Firefox uses an IAccessible2 fallback since it doesn't expose `RootWebArea` via UIA).
 
 ## 🛠️Installation
 

--- a/src/windows_mcp/tools/scrape.py
+++ b/src/windows_mcp/tools/scrape.py
@@ -8,7 +8,7 @@ from fastmcp import Context
 def register(mcp, *, get_desktop, get_analytics):
     @mcp.tool(
         name="Scrape",
-        description="Fetch/scrape web page content from a URL. Keywords: scrape, fetch, browse, web, URL, extract, download, read webpage. By default (use_dom=False), performs a lightweight HTTP request to the URL and returns a clean LLM-processed summary of the page to avoid context bloat. Provide query to focus extraction on specific information. Set use_dom=True to extract from the active browser tab's DOM instead (required when site blocks HTTP requests). Set use_sampling=False to get raw content without LLM processing.",
+        description="Fetch/scrape web page content from a URL. Keywords: scrape, fetch, browse, web, URL, extract, download, read webpage. By default (use_dom=False), performs a lightweight HTTP request to the URL and returns a clean LLM-processed summary of the page to avoid context bloat. Provide query to focus extraction on specific information. Set use_dom=True to extract from the active browser tab's DOM instead (required when site blocks HTTP requests; supported in Chrome, Edge, and Firefox). Set use_sampling=False to get raw content without LLM processing.",
         annotations=ToolAnnotations(
             title="Scrape",
             readOnlyHint=True,

--- a/src/windows_mcp/tree/ia2.py
+++ b/src/windows_mcp/tree/ia2.py
@@ -19,54 +19,48 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
+from _ctypes import COMError
+
 from windows_mcp.tree.views import BoundingBox, TextElementNode, TreeElementNode
 
 logger = logging.getLogger(__name__)
 
 
-# ---------------------------------------------------------------------------
-# COM interface bootstrap (deferred — keeps the module importable on Linux for
-# the pure-Python helpers below; the COM-touching code is only reached at
-# runtime on Windows.)
-# ---------------------------------------------------------------------------
-
 _IAccessible = None
-_COMError = None
+_oleacc_signatures_set = False
 
 
 def _iaccessible():
-    """Lazily resolve the IAccessible interface class from oleacc.dll's type library."""
-    global _IAccessible, _COMError
+    """Lazily resolve the IAccessible interface class and bind oleacc signatures.
+
+    Deferred until first use so the module imports cleanly without a COM dispatch.
+    The signature bind is idempotent but guarded so we don't pay the attribute
+    writes on every traverse_window call.
+    """
+    global _IAccessible, _oleacc_signatures_set
     if _IAccessible is None:
+        import ctypes
+        from ctypes import wintypes
+
         import comtypes  # noqa: F401  (forces COM module init)
         import comtypes.client
-        from _ctypes import COMError as _ComErrorCls
+        from comtypes import GUID
 
         comtypes.client.GetModule("oleacc.dll")
         from comtypes.gen.Accessibility import IAccessible  # type: ignore
 
         _IAccessible = IAccessible
-        _COMError = _ComErrorCls
+
+        oleacc = ctypes.windll.oleacc
+        oleacc.AccessibleObjectFromWindow.argtypes = [
+            wintypes.HWND,
+            wintypes.DWORD,
+            ctypes.POINTER(GUID),
+            ctypes.POINTER(ctypes.POINTER(IAccessible)),
+        ]
+        oleacc.AccessibleObjectFromWindow.restype = ctypes.HRESULT
+        _oleacc_signatures_set = True
     return _IAccessible
-
-
-class _UnavailableCOMError(Exception):
-    """Sentinel exception type used when the real COMError isn't importable
-    (i.e. when this module is being unit-tested on a non-Windows host).
-    Catching this in ``except`` blocks is a no-op since no real call will ever
-    raise it on that platform."""
-
-
-def _com_error_cls():
-    """Return the COMError class (lazy — only available on Windows)."""
-    global _COMError
-    if _COMError is None:
-        try:
-            from _ctypes import COMError as _ComErrorCls  # type: ignore
-        except ImportError:
-            _ComErrorCls = _UnavailableCOMError
-        _COMError = _ComErrorCls
-    return _COMError
 
 
 # OBJID_CLIENT — request the client-area accessible object
@@ -83,7 +77,6 @@ CHILDID_SELF = 0
 ROLE_DOCUMENT = 0x0F
 ROLE_GROUPING = 0x14
 ROLE_TOOLBAR = 0x16
-ROLE_STATUSBAR = 0x17
 ROLE_TABLE = 0x18
 ROLE_LINK = 0x1E
 ROLE_LIST = 0x21
@@ -99,13 +92,11 @@ ROLE_CHECKBUTTON = 0x2C
 ROLE_RADIOBUTTON = 0x2D
 ROLE_COMBOBOX = 0x2E
 ROLE_DROPLIST = 0x2F
-ROLE_PROGRESSBAR = 0x30
 ROLE_SLIDER = 0x33
 ROLE_BUTTONDROPDOWN = 0x38
 ROLE_PAGETABLIST = 0x3C
 ROLE_SPLITBUTTON = 0x3E
 
-STATE_SYSTEM_UNAVAILABLE = 0x00000001
 STATE_SYSTEM_FOCUSED = 0x00000004
 STATE_SYSTEM_INVISIBLE = 0x00008000
 STATE_SYSTEM_OFFSCREEN = 0x00010000
@@ -138,7 +129,9 @@ ROLE_NAMES: dict[int, str] = {
     ROLE_SPLITBUTTON: "button",
 }
 
-INTERACTIVE_ROLES: set[int] = {
+# Disambiguated from windows_mcp.tree.config.INTERACTIVE_ROLES which holds UIA
+# (string) roles. These are MSAA integer roles for the IA2 fallback path.
+INTERACTIVE_MSAA_ROLES: set[int] = {
     ROLE_LINK,
     ROLE_PUSHBUTTON,
     ROLE_CHECKBUTTON,
@@ -153,7 +146,7 @@ INTERACTIVE_ROLES: set[int] = {
     ROLE_SPLITBUTTON,
 }
 
-INFORMATIVE_ROLES: set[int] = {
+INFORMATIVE_MSAA_ROLES: set[int] = {
     ROLE_STATICTEXT,
     ROLE_TEXT,
 }
@@ -191,20 +184,9 @@ def role_name(role: object) -> str:
 def _accessible_object_from_window(hwnd: int):
     """Wrap oleacc!AccessibleObjectFromWindow and return a comtypes IAccessible pointer."""
     import ctypes
-    from ctypes import wintypes
 
-    from comtypes import GUID  # noqa: F401  (re-exported for type clarity)
-
-    iface = _iaccessible()
+    iface = _iaccessible()  # binds argtypes/restype on first call
     oleacc = ctypes.windll.oleacc
-
-    oleacc.AccessibleObjectFromWindow.argtypes = [
-        wintypes.HWND,
-        wintypes.DWORD,
-        ctypes.POINTER(GUID),
-        ctypes.POINTER(ctypes.POINTER(iface)),
-    ]
-    oleacc.AccessibleObjectFromWindow.restype = ctypes.HRESULT
 
     pacc = ctypes.POINTER(iface)()
     hr = oleacc.AccessibleObjectFromWindow(
@@ -226,7 +208,6 @@ def _accessible_object_from_window(hwnd: int):
 
 
 def _acc_role(iacc) -> object:
-    COMError = _com_error_cls()
     try:
         return iacc.accRole(CHILDID_SELF)
     except COMError:
@@ -234,18 +215,14 @@ def _acc_role(iacc) -> object:
 
 
 def _acc_state(iacc) -> int:
-    COMError = _com_error_cls()
     try:
         state = iacc.accState(CHILDID_SELF)
-        return int(state) if isinstance(state, int) else 0
-    except COMError:
-        return 0
-    except (TypeError, ValueError):
+        return state if isinstance(state, int) else 0
+    except (COMError, TypeError, ValueError):
         return 0
 
 
 def _acc_name(iacc) -> str:
-    COMError = _com_error_cls()
     try:
         name = iacc.accName(CHILDID_SELF)
         return (name or "").strip()
@@ -254,7 +231,6 @@ def _acc_name(iacc) -> str:
 
 
 def _acc_value(iacc) -> str:
-    COMError = _com_error_cls()
     try:
         value = iacc.accValue(CHILDID_SELF)
         return (value or "").strip()
@@ -264,19 +240,15 @@ def _acc_value(iacc) -> str:
 
 def _acc_location(iacc) -> Optional[tuple[int, int, int, int]]:
     """Return (left, top, width, height) for the element, or None on failure."""
-    COMError = _com_error_cls()
     try:
         # accLocation has out-params; comtypes returns a tuple.
         left, top, width, height = iacc.accLocation(CHILDID_SELF)
         return int(left), int(top), int(width), int(height)
-    except COMError:
-        return None
-    except (TypeError, ValueError):
+    except (COMError, TypeError, ValueError):
         return None
 
 
 def _acc_child_count(iacc) -> int:
-    COMError = _com_error_cls()
     try:
         return int(iacc.accChildCount)
     except (COMError, TypeError, ValueError):
@@ -285,7 +257,6 @@ def _acc_child_count(iacc) -> int:
 
 def _iter_children(iacc, iface):
     """Yield IAccessible children. Skips simple-child entries (no IDispatch)."""
-    COMError = _com_error_cls()
     count = _acc_child_count(iacc)
     if count <= 0:
         return
@@ -380,7 +351,6 @@ class _Walker:
         if self.in_document > 0 and _is_visible(state, location):
             self._record(iacc, role, state, location)
 
-        COMError = _com_error_cls()
         for child in _iter_children(iacc, iface):
             try:
                 self.walk(child, iface, depth + 1)
@@ -405,33 +375,29 @@ class _Walker:
         role_label = role_name(role)
         name = _acc_name(iacc)
 
-        if role_int in INFORMATIVE_ROLES:
+        if role_int in INFORMATIVE_MSAA_ROLES:
             if name:
                 self.informative.append(TextElementNode(text=name))
             return
 
-        if role_int in INTERACTIVE_ROLES or (state & STATE_SYSTEM_LINKED):
+        if role_int in INTERACTIVE_MSAA_ROLES or (state & STATE_SYSTEM_LINKED):
             bbox = _bounding_box_from_location(location, self.dom_clip)
             if bbox.width <= 0 or bbox.height <= 0:
                 return
-            center = bbox.get_center()
-            metadata: dict[str, object] = {}
-            if state & STATE_SYSTEM_FOCUSED:
-                metadata["has_focused"] = True
-            if not (state & STATE_SYSTEM_FOCUSED):
-                metadata.setdefault("has_focused", False)
+            metadata: dict[str, object] = {
+                "has_focused": bool(state & STATE_SYSTEM_FOCUSED),
+            }
             value = _acc_value(iacc)
             if value and role_int == ROLE_LINK:
                 metadata["url"] = value
             elif value and role_int in {ROLE_COMBOBOX, ROLE_DROPLIST, ROLE_SLIDER}:
                 metadata["value"] = value
-            display_name = name or value or role_label
             self.interactive.append(
                 TreeElementNode(
-                    name=display_name,
-                    control_type=role_label.title() or "Unknown",
+                    name=name or value or role_label,
+                    control_type=role_label.title(),
                     bounding_box=bbox,
-                    center=center,
+                    center=bbox.get_center(),
                     window_name=self.window_name,
                     metadata=metadata,
                 )
@@ -515,11 +481,17 @@ def traverse_window(
         return IA2TraversalResult(window_bounding_box, [], [])
 
     walker = _Walker(window_name=window_name, dom_clip=window_bounding_box)
-    COMError = _com_error_cls()
     try:
         walker.walk(root, iface)
     except COMError as e:
         logger.warning("IA2 walk for hwnd %#x aborted with COMError: %s", hwnd, e)
+
+    if walker.seen >= MAX_NODES:
+        logger.warning(
+            "IA2 walk for '%s' hit MAX_NODES=%d cap; output is truncated",
+            window_name,
+            MAX_NODES,
+        )
 
     # Prefer the active document's bbox (the web content area) over the window bbox.
     # Falls back to the window bbox if no document was found in the tree.

--- a/src/windows_mcp/tree/ia2.py
+++ b/src/windows_mcp/tree/ia2.py
@@ -1,0 +1,492 @@
+"""IAccessible (MSAA / IA2) tree traversal for Firefox web DOM extraction.
+
+Firefox exposes its browser chrome via UIA but its web DOM only via MSAA / IAccessible2.
+The UIA traversal in :mod:`windows_mcp.tree.service` looks for an element with
+``AutomationId == "RootWebArea"`` (the Chrome / Edge convention) to enter "DOM mode" —
+Firefox has no such marker, so DOM extraction is skipped entirely.
+
+This module fetches the root ``IAccessible`` from a Firefox window handle via
+``AccessibleObjectFromWindow`` (oleacc.dll) and walks the resulting tree, collecting
+text and interactive elements in the same shape used by the UIA path:
+
+- ``dom_informative_nodes`` — list[TextElementNode]
+- ``dom_interactive_nodes`` — list[TreeElementNode]
+- ``dom_bounding_box`` — BoundingBox of the web content area
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from windows_mcp.tree.views import BoundingBox, TextElementNode, TreeElementNode
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# COM interface bootstrap (deferred — keeps the module importable on Linux for
+# the pure-Python helpers below; the COM-touching code is only reached at
+# runtime on Windows.)
+# ---------------------------------------------------------------------------
+
+_IAccessible = None
+_COMError = None
+
+
+def _iaccessible():
+    """Lazily resolve the IAccessible interface class from oleacc.dll's type library."""
+    global _IAccessible, _COMError
+    if _IAccessible is None:
+        import comtypes  # noqa: F401  (forces COM module init)
+        import comtypes.client
+        from _ctypes import COMError as _ComErrorCls
+
+        comtypes.client.GetModule("oleacc.dll")
+        from comtypes.gen.Accessibility import IAccessible  # type: ignore
+
+        _IAccessible = IAccessible
+        _COMError = _ComErrorCls
+    return _IAccessible
+
+
+class _UnavailableCOMError(Exception):
+    """Sentinel exception type used when the real COMError isn't importable
+    (i.e. when this module is being unit-tested on a non-Windows host).
+    Catching this in ``except`` blocks is a no-op since no real call will ever
+    raise it on that platform."""
+
+
+def _com_error_cls():
+    """Return the COMError class (lazy — only available on Windows)."""
+    global _COMError
+    if _COMError is None:
+        try:
+            from _ctypes import COMError as _ComErrorCls  # type: ignore
+        except ImportError:
+            _ComErrorCls = _UnavailableCOMError
+        _COMError = _ComErrorCls
+    return _COMError
+
+
+# OBJID_CLIENT — request the client-area accessible object
+OBJID_CLIENT = 0xFFFFFFFC
+
+# CHILDID_SELF — refer to the element itself (vs. a simple child index)
+CHILDID_SELF = 0
+
+
+# ---------------------------------------------------------------------------
+# MSAA role / state constants (oleacc.h)
+# ---------------------------------------------------------------------------
+
+ROLE_DOCUMENT = 0x0F
+ROLE_GROUPING = 0x14
+ROLE_TOOLBAR = 0x16
+ROLE_STATUSBAR = 0x17
+ROLE_TABLE = 0x18
+ROLE_LINK = 0x1E
+ROLE_LIST = 0x21
+ROLE_LISTITEM = 0x22
+ROLE_OUTLINE = 0x23
+ROLE_OUTLINEITEM = 0x24
+ROLE_PAGETAB = 0x25
+ROLE_GRAPHIC = 0x28
+ROLE_STATICTEXT = 0x29
+ROLE_TEXT = 0x2A
+ROLE_PUSHBUTTON = 0x2B
+ROLE_CHECKBUTTON = 0x2C
+ROLE_RADIOBUTTON = 0x2D
+ROLE_COMBOBOX = 0x2E
+ROLE_DROPLIST = 0x2F
+ROLE_PROGRESSBAR = 0x30
+ROLE_SLIDER = 0x33
+ROLE_BUTTONDROPDOWN = 0x38
+ROLE_PAGETABLIST = 0x3C
+ROLE_SPLITBUTTON = 0x3E
+
+STATE_SYSTEM_UNAVAILABLE = 0x00000001
+STATE_SYSTEM_FOCUSED = 0x00000004
+STATE_SYSTEM_INVISIBLE = 0x00008000
+STATE_SYSTEM_OFFSCREEN = 0x00010000
+STATE_SYSTEM_FOCUSABLE = 0x00100000
+STATE_SYSTEM_LINKED = 0x00400000
+
+
+ROLE_NAMES: dict[int, str] = {
+    ROLE_DOCUMENT: "document",
+    ROLE_GROUPING: "grouping",
+    ROLE_TOOLBAR: "toolbar",
+    ROLE_TABLE: "table",
+    ROLE_LINK: "link",
+    ROLE_LIST: "list",
+    ROLE_LISTITEM: "list item",
+    ROLE_OUTLINE: "outline",
+    ROLE_OUTLINEITEM: "outline item",
+    ROLE_PAGETAB: "tab",
+    ROLE_GRAPHIC: "graphic",
+    ROLE_STATICTEXT: "text",
+    ROLE_TEXT: "text",
+    ROLE_PUSHBUTTON: "button",
+    ROLE_CHECKBUTTON: "check box",
+    ROLE_RADIOBUTTON: "radio button",
+    ROLE_COMBOBOX: "combo box",
+    ROLE_DROPLIST: "drop list",
+    ROLE_SLIDER: "slider",
+    ROLE_BUTTONDROPDOWN: "button",
+    ROLE_PAGETABLIST: "tab list",
+    ROLE_SPLITBUTTON: "button",
+}
+
+INTERACTIVE_ROLES: set[int] = {
+    ROLE_LINK,
+    ROLE_PUSHBUTTON,
+    ROLE_CHECKBUTTON,
+    ROLE_RADIOBUTTON,
+    ROLE_COMBOBOX,
+    ROLE_DROPLIST,
+    ROLE_SLIDER,
+    ROLE_LISTITEM,
+    ROLE_OUTLINEITEM,
+    ROLE_PAGETAB,
+    ROLE_BUTTONDROPDOWN,
+    ROLE_SPLITBUTTON,
+}
+
+INFORMATIVE_ROLES: set[int] = {
+    ROLE_STATICTEXT,
+    ROLE_TEXT,
+}
+
+# Walk caps — Firefox's a11y tree can be huge on heavy pages.
+# Caps apply to the active document subtree; chrome and inactive tabs are pruned first.
+MAX_DEPTH = 500
+MAX_NODES = 30000
+
+
+def role_name(role: object) -> str:
+    """Map an accRole result (int or BSTR) to a friendly control-type name."""
+    if isinstance(role, str):
+        return role.strip().lower() or "unknown"
+    if isinstance(role, int):
+        return ROLE_NAMES.get(role, "unknown")
+    return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# IAccessible acquisition
+# ---------------------------------------------------------------------------
+
+
+def _accessible_object_from_window(hwnd: int):
+    """Wrap oleacc!AccessibleObjectFromWindow and return a comtypes IAccessible pointer."""
+    import ctypes
+    from ctypes import wintypes
+
+    from comtypes import GUID  # noqa: F401  (re-exported for type clarity)
+
+    iface = _iaccessible()
+    oleacc = ctypes.windll.oleacc
+
+    oleacc.AccessibleObjectFromWindow.argtypes = [
+        wintypes.HWND,
+        wintypes.DWORD,
+        ctypes.POINTER(GUID),
+        ctypes.POINTER(ctypes.POINTER(iface)),
+    ]
+    oleacc.AccessibleObjectFromWindow.restype = ctypes.HRESULT
+
+    pacc = ctypes.POINTER(iface)()
+    hr = oleacc.AccessibleObjectFromWindow(
+        hwnd,
+        OBJID_CLIENT,
+        ctypes.byref(iface._iid_),
+        ctypes.byref(pacc),
+    )
+    if hr != 0:
+        raise OSError(f"AccessibleObjectFromWindow failed: HRESULT=0x{hr & 0xFFFFFFFF:08X}")
+    if not pacc:
+        raise RuntimeError("AccessibleObjectFromWindow returned a null pointer")
+    return pacc
+
+
+# ---------------------------------------------------------------------------
+# Property accessors — every IAccessible call can throw COMError; isolate them.
+# ---------------------------------------------------------------------------
+
+
+def _acc_role(iacc) -> object:
+    COMError = _com_error_cls()
+    try:
+        return iacc.accRole(CHILDID_SELF)
+    except COMError:
+        return -1
+
+
+def _acc_state(iacc) -> int:
+    COMError = _com_error_cls()
+    try:
+        state = iacc.accState(CHILDID_SELF)
+        return int(state) if isinstance(state, int) else 0
+    except COMError:
+        return 0
+    except (TypeError, ValueError):
+        return 0
+
+
+def _acc_name(iacc) -> str:
+    COMError = _com_error_cls()
+    try:
+        name = iacc.accName(CHILDID_SELF)
+        return (name or "").strip()
+    except COMError:
+        return ""
+
+
+def _acc_value(iacc) -> str:
+    COMError = _com_error_cls()
+    try:
+        value = iacc.accValue(CHILDID_SELF)
+        return (value or "").strip()
+    except COMError:
+        return ""
+
+
+def _acc_location(iacc) -> Optional[tuple[int, int, int, int]]:
+    """Return (left, top, width, height) for the element, or None on failure."""
+    COMError = _com_error_cls()
+    try:
+        # accLocation has out-params; comtypes returns a tuple.
+        left, top, width, height = iacc.accLocation(CHILDID_SELF)
+        return int(left), int(top), int(width), int(height)
+    except COMError:
+        return None
+    except (TypeError, ValueError):
+        return None
+
+
+def _acc_child_count(iacc) -> int:
+    COMError = _com_error_cls()
+    try:
+        return int(iacc.accChildCount)
+    except (COMError, TypeError, ValueError):
+        return 0
+
+
+def _iter_children(iacc, iface):
+    """Yield IAccessible children. Skips simple-child entries (no IDispatch)."""
+    COMError = _com_error_cls()
+    count = _acc_child_count(iacc)
+    if count <= 0:
+        return
+    for index in range(1, count + 1):
+        try:
+            disp = iacc.accChild(index)
+        except COMError:
+            continue
+        if disp is None:
+            continue
+        try:
+            child = disp.QueryInterface(iface)
+        except (COMError, AttributeError):
+            continue
+        yield child
+
+
+# ---------------------------------------------------------------------------
+# Traversal
+# ---------------------------------------------------------------------------
+
+
+def _bounding_box_from_location(
+    location: tuple[int, int, int, int], clip: Optional[BoundingBox]
+) -> BoundingBox:
+    left, top, width, height = location
+    right, bottom = left + width, top + height
+    if clip is not None:
+        left = max(left, clip.left)
+        top = max(top, clip.top)
+        right = min(right, clip.right)
+        bottom = min(bottom, clip.bottom)
+    width = max(0, right - left)
+    height = max(0, bottom - top)
+    return BoundingBox(left=left, top=top, right=right, bottom=bottom, width=width, height=height)
+
+
+def _is_visible(state: int, location: Optional[tuple[int, int, int, int]]) -> bool:
+    if state & (STATE_SYSTEM_INVISIBLE | STATE_SYSTEM_OFFSCREEN):
+        return False
+    if location is None:
+        return False
+    _, _, width, height = location
+    return width > 0 and height > 0
+
+
+class _Walker:
+    """Encapsulates traversal state (caps, counts, output buffers).
+
+    Scoping rules:
+    1. Invisible / offscreen subtrees are pruned entirely (don't descend). This is
+       what filters out Firefox's inactive tabs — their document subtrees are marked
+       invisible.
+    2. Content is only recorded while inside a ROLE_DOCUMENT subtree. This filters
+       out Firefox chrome (toolbar, tab strip, URL bar, bookmarks) which would
+       otherwise dominate the output.
+    3. The first visible document we enter sets ``active_document_box`` — used by
+       ``traverse_window`` as the DOM bounding box.
+    """
+
+    def __init__(self, window_name: str, dom_clip: Optional[BoundingBox]):
+        self.window_name = window_name
+        self.dom_clip = dom_clip
+        self.informative: list[TextElementNode] = []
+        self.interactive: list[TreeElementNode] = []
+        self.seen = 0
+        self.in_document = 0  # depth of nested documents (iframes etc.)
+        self.active_document_box: Optional[BoundingBox] = None
+
+    def walk(self, iacc, iface, depth: int = 0) -> None:
+        if depth > MAX_DEPTH or self.seen >= MAX_NODES:
+            return
+        self.seen += 1
+
+        role = _acc_role(iacc)
+        state = _acc_state(iacc)
+        location = _acc_location(iacc)
+
+        # Prune entire invisible subtrees. Always descend from the root (depth==0)
+        # because the window root itself may report an unusual bbox.
+        if depth > 0 and not _is_visible(state, location):
+            return
+
+        role_int = role if isinstance(role, int) else -1
+        is_document = role_int == ROLE_DOCUMENT
+        if is_document:
+            self.in_document += 1
+            if self.active_document_box is None and location is not None:
+                self.active_document_box = _bounding_box_from_location(location, self.dom_clip)
+
+        # Only record content while we're inside (or at the root of) a document subtree.
+        if self.in_document > 0 and _is_visible(state, location):
+            self._record(iacc, role, state, location)
+
+        COMError = _com_error_cls()
+        for child in _iter_children(iacc, iface):
+            try:
+                self.walk(child, iface, depth + 1)
+            except COMError as e:
+                logger.debug("Skipping IA2 subtree due to COMError: %s", e)
+                continue
+
+        if is_document:
+            self.in_document -= 1
+
+    def _record(
+        self,
+        iacc,
+        role: object,
+        state: int,
+        location: Optional[tuple[int, int, int, int]],
+    ) -> None:
+        if location is None:
+            return
+
+        role_int = role if isinstance(role, int) else -1
+        role_label = role_name(role)
+        name = _acc_name(iacc)
+
+        if role_int in INFORMATIVE_ROLES:
+            if name:
+                self.informative.append(TextElementNode(text=name))
+            return
+
+        if role_int in INTERACTIVE_ROLES or (state & STATE_SYSTEM_LINKED):
+            bbox = _bounding_box_from_location(location, self.dom_clip)
+            if bbox.width <= 0 or bbox.height <= 0:
+                return
+            center = bbox.get_center()
+            metadata: dict[str, object] = {}
+            if state & STATE_SYSTEM_FOCUSED:
+                metadata["has_focused"] = True
+            if not (state & STATE_SYSTEM_FOCUSED):
+                metadata.setdefault("has_focused", False)
+            value = _acc_value(iacc)
+            if value and role_int == ROLE_LINK:
+                metadata["url"] = value
+            elif value and role_int in {ROLE_COMBOBOX, ROLE_DROPLIST, ROLE_SLIDER}:
+                metadata["value"] = value
+            display_name = name or value or role_label
+            self.interactive.append(
+                TreeElementNode(
+                    name=display_name,
+                    control_type=role_label.title() or "Unknown",
+                    bounding_box=bbox,
+                    center=center,
+                    window_name=self.window_name,
+                    metadata=metadata,
+                )
+            )
+            return
+
+        # ROLE_GRAPHIC with a non-empty alt text — surface as informative text.
+        if role_int == ROLE_GRAPHIC and name:
+            self.informative.append(TextElementNode(text=name))
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+class IA2TraversalResult:
+    """Output of :func:`traverse_window`."""
+
+    __slots__ = ("dom_bounding_box", "informative_nodes", "interactive_nodes")
+
+    def __init__(
+        self,
+        dom_bounding_box: Optional[BoundingBox],
+        informative_nodes: list[TextElementNode],
+        interactive_nodes: list[TreeElementNode],
+    ):
+        self.dom_bounding_box = dom_bounding_box
+        self.informative_nodes = informative_nodes
+        self.interactive_nodes = interactive_nodes
+
+    def __bool__(self) -> bool:
+        return bool(self.informative_nodes or self.interactive_nodes)
+
+
+def traverse_window(
+    hwnd: int,
+    window_name: str,
+    window_bounding_box: Optional[BoundingBox] = None,
+) -> IA2TraversalResult:
+    """Walk the IAccessible tree of *hwnd* and return DOM-shaped node lists.
+
+    ``window_bounding_box`` is used to clip element rectangles to the window's
+    visible area, matching what the UIA path does via :py:meth:`Tree.iou_bounding_box`.
+    """
+    iface = _iaccessible()
+    try:
+        root = _accessible_object_from_window(hwnd)
+    except (OSError, RuntimeError) as e:
+        logger.warning("IA2 acquisition failed for hwnd %#x: %s", hwnd, e)
+        return IA2TraversalResult(window_bounding_box, [], [])
+
+    walker = _Walker(window_name=window_name, dom_clip=window_bounding_box)
+    COMError = _com_error_cls()
+    try:
+        walker.walk(root, iface)
+    except COMError as e:
+        logger.warning("IA2 walk for hwnd %#x aborted with COMError: %s", hwnd, e)
+
+    # Prefer the active document's bbox (the web content area) over the window bbox.
+    # Falls back to the window bbox if no document was found in the tree.
+    dom_bbox = walker.active_document_box or window_bounding_box
+
+    return IA2TraversalResult(
+        dom_bounding_box=dom_bbox,
+        informative_nodes=walker.informative,
+        interactive_nodes=walker.interactive,
+    )

--- a/src/windows_mcp/tree/ia2.py
+++ b/src/windows_mcp/tree/ia2.py
@@ -165,7 +165,17 @@ MAX_NODES = 30000
 
 
 def role_name(role: object) -> str:
-    """Map an accRole result (int or BSTR) to a friendly control-type name."""
+    """Map an ``accRole`` result to a friendly control-type name.
+
+    Args:
+        role: Either an ``int`` role constant (the usual MSAA case, e.g.
+            ``ROLE_LINK``) or a ``BSTR`` string (Firefox returns these for IA2
+            role extensions like ``"heading"`` or ``"article"``).
+
+    Returns:
+        Lower-cased role name (e.g. ``"link"``, ``"button"``, ``"heading"``),
+        or ``"unknown"`` if the role can't be mapped or is empty.
+    """
     if isinstance(role, str):
         return role.strip().lower() or "unknown"
     if isinstance(role, int):
@@ -439,7 +449,20 @@ class _Walker:
 
 
 class IA2TraversalResult:
-    """Output of :func:`traverse_window`."""
+    """Result of a single :func:`traverse_window` call.
+
+    Attributes:
+        dom_bounding_box: Bounding box of the active document element, or
+            the fallback window box if no document was found. ``None`` only
+            when both inputs were ``None``.
+        informative_nodes: ``TextElementNode`` list for visible non-interactive
+            content (headings, paragraphs, alt text, etc.).
+        interactive_nodes: ``TreeElementNode`` list for clickable / focusable
+            elements (links, buttons, form fields).
+
+    The instance is falsy when both node lists are empty — call sites use
+    ``if result:`` to skip the no-DOM case.
+    """
 
     __slots__ = ("dom_bounding_box", "informative_nodes", "interactive_nodes")
 
@@ -462,10 +485,27 @@ def traverse_window(
     window_name: str,
     window_bounding_box: Optional[BoundingBox] = None,
 ) -> IA2TraversalResult:
-    """Walk the IAccessible tree of *hwnd* and return DOM-shaped node lists.
+    """Walk the IAccessible tree of ``hwnd`` and return DOM-shaped node lists.
 
-    ``window_bounding_box`` is used to clip element rectangles to the window's
-    visible area, matching what the UIA path does via :py:meth:`Tree.iou_bounding_box`.
+    Used as a fallback for Firefox, whose web DOM is only reachable via
+    MSAA / IAccessible2 (it does not expose ``RootWebArea`` through UIA).
+
+    Args:
+        hwnd: Win32 window handle of the browser window to walk.
+        window_name: Title of the window, attached to each emitted node for
+            downstream display and matching against active-window state.
+        window_bounding_box: Outer window rectangle. Used to clip element
+            rectangles to the visible area, matching what the UIA path does
+            via :py:meth:`Tree.iou_bounding_box`. ``None`` disables clipping.
+
+    Returns:
+        :class:`IA2TraversalResult` containing the (possibly empty)
+        informative and interactive node lists plus the bounding box of the
+        active document (or ``window_bounding_box`` if no document was found).
+
+    The function never raises: COM acquisition or walk failures are logged at
+    ``WARNING`` and an empty :class:`IA2TraversalResult` is returned so callers
+    can fall back to the no-DOM error path.
     """
     iface = _iaccessible()
     try:

--- a/src/windows_mcp/tree/service.py
+++ b/src/windows_mcp/tree/service.py
@@ -772,8 +772,12 @@ class Tree:
                     if ia2_result:
                         dom_interactive_nodes.extend(ia2_result.interactive_nodes)
                         dom_informative_nodes.extend(ia2_result.informative_nodes)
-                        self.dom_bounding_box = ia2_result.dom_bounding_box or window_box
-                        self.dom_is_ia2 = True
+                        # Pin the bbox to the FIRST Firefox window walked (the active
+                        # one — it's first in windows_handles). Subsequent windows
+                        # contribute nodes but mustn't clobber the active window's bbox.
+                        if not self.dom_is_ia2:
+                            self.dom_bounding_box = ia2_result.dom_bounding_box or window_box
+                            self.dom_is_ia2 = True
                         logger.info(
                             "IA2 fallback for '%s' produced %d interactive / %d informative nodes in %.1fms",
                             window_name,

--- a/src/windows_mcp/tree/service.py
+++ b/src/windows_mcp/tree/service.py
@@ -4,6 +4,7 @@ from windows_mcp.tree.config import INTERACTIVE_CONTROL_TYPE_NAMES, DOCUMENT_CON
 from windows_mcp.tree.views import TreeElementNode, ScrollElementNode, TextElementNode, Center, BoundingBox, TreeState, SemanticNode, _prune_structural, _reverse_children_order
 from windows_mcp.tree.cache_utils import CacheRequestFactory, CachedControlHelper
 from windows_mcp.tree.utils import random_point_within_bounding_box
+from windows_mcp.tree import ia2 as ia2_traversal
 from typing import TYPE_CHECKING,Optional,Any
 from time import sleep,perf_counter
 import logging
@@ -46,6 +47,7 @@ class Tree:
         self.screen_size=desktop.get_screen_size()
         self.dom:Optional[Control]=None
         self.dom_bounding_box:BoundingBox=None
+        self.dom_is_ia2:bool=False
         self.screen_box=BoundingBox(
             top=0, left=0, bottom=self.screen_size.height, right=self.screen_size.width,
             width=self.screen_size.width, height=self.screen_size.height
@@ -57,6 +59,7 @@ class Tree:
         # Reset DOM state to prevent leaks and stale data
         self.dom = None
         self.dom_bounding_box = None
+        self.dom_is_ia2 = False
         start_time = perf_counter()
         profile_enabled = _snapshot_profile_enabled()
 
@@ -97,6 +100,24 @@ class Tree:
             except Exception as e:
                 logger.debug(f"Failed to get DOM scroll pattern: {e}")
                 dom_node=None
+        elif self.dom_is_ia2 and self.dom_bounding_box is not None:
+            # Firefox / IA2 path — no UIA scroll pattern, so emit a stub ScrollElementNode
+            # with scrolling disabled. Downstream consumers (Scrape) only need a truthy
+            # dom_node and the bounding box.
+            dom_node=ScrollElementNode(**{
+                'name':'DOM',
+                'control_type':'DocumentControl',
+                'bounding_box':self.dom_bounding_box,
+                'center':self.dom_bounding_box.get_center(),
+                'window_name':'DOM',
+                'metadata':{
+                    'has_focused': False,
+                    'horizontal_scrollable': False,
+                    'horizontal_scroll_percent': 0,
+                    'vertical_scrollable': False,
+                    'vertical_scroll_percent': 0,
+                }
+            })
         else:
             dom_node=None
         # Build semantic tree: desktop → windows → structural/interactive/scrollable
@@ -727,6 +748,42 @@ class Tree:
                 )
 
             self.tree_traversal(node, window_bounding_box, window_name, is_browser, interactive_nodes, scrollable_nodes, dom_interactive_nodes, dom_informative_nodes, is_dom=False, is_dialog=False, element_cache_req=element_cache_req, children_cache_req=children_cache_req, current_semantic_node=window_sem_node)
+
+            # IA2 fallback: Firefox doesn't expose RootWebArea via UIA, so the traversal
+            # above finds no DOM content. If this is a browser window and UIA gave us no
+            # DOM, walk the IAccessible tree (MSAA / IA2) instead.
+            if is_browser and use_dom and self.dom is None:
+                try:
+                    window_box = BoundingBox(
+                        left=window_bounding_box.left,
+                        top=window_bounding_box.top,
+                        right=window_bounding_box.right,
+                        bottom=window_bounding_box.bottom,
+                        width=window_bounding_box.width(),
+                        height=window_bounding_box.height(),
+                    )
+                    ia2_t0 = perf_counter()
+                    ia2_result = ia2_traversal.traverse_window(
+                        hwnd=handle,
+                        window_name=window_name,
+                        window_bounding_box=window_box,
+                    )
+                    ia2_ms = (perf_counter() - ia2_t0) * 1000
+                    if ia2_result:
+                        dom_interactive_nodes.extend(ia2_result.interactive_nodes)
+                        dom_informative_nodes.extend(ia2_result.informative_nodes)
+                        self.dom_bounding_box = ia2_result.dom_bounding_box or window_box
+                        self.dom_is_ia2 = True
+                        logger.info(
+                            "IA2 fallback for '%s' produced %d interactive / %d informative nodes in %.1fms",
+                            window_name,
+                            len(ia2_result.interactive_nodes),
+                            len(ia2_result.informative_nodes),
+                            ia2_ms,
+                        )
+                except Exception as e:
+                    logger.warning("IA2 fallback failed for '%s' (handle %#x): %s", window_name, handle, e)
+
             logger.debug(f'Window name:{window_name}')
             logger.debug(f'Interactive nodes:{len(interactive_nodes)}')
             if is_browser:

--- a/tests/test_tree_ia2.py
+++ b/tests/test_tree_ia2.py
@@ -94,14 +94,14 @@ class TestRoleClassification:
             ia2.ROLE_CHECKBUTTON,
             ia2.ROLE_RADIOBUTTON,
         ):
-            assert role in ia2.INTERACTIVE_ROLES
+            assert role in ia2.INTERACTIVE_MSAA_ROLES
 
     def test_informative_roles_contains_text(self):
-        assert ia2.ROLE_STATICTEXT in ia2.INFORMATIVE_ROLES
-        assert ia2.ROLE_TEXT in ia2.INFORMATIVE_ROLES
+        assert ia2.ROLE_STATICTEXT in ia2.INFORMATIVE_MSAA_ROLES
+        assert ia2.ROLE_TEXT in ia2.INFORMATIVE_MSAA_ROLES
 
     def test_disjoint_role_sets(self):
-        assert not (ia2.INTERACTIVE_ROLES & ia2.INFORMATIVE_ROLES)
+        assert not (ia2.INTERACTIVE_MSAA_ROLES & ia2.INFORMATIVE_MSAA_ROLES)
 
 
 class TestWalkerRecord:

--- a/tests/test_tree_ia2.py
+++ b/tests/test_tree_ia2.py
@@ -1,0 +1,414 @@
+"""Tests for the IAccessible2 / MSAA traversal helpers.
+
+Only the pure-Python helpers are exercised here — the actual COM traversal is
+Windows-only and requires a live Firefox window, so it's left for manual /
+integration testing.
+"""
+
+from unittest.mock import MagicMock
+
+from windows_mcp.tree import ia2
+from windows_mcp.tree.views import BoundingBox, TextElementNode, TreeElementNode
+
+
+class TestRoleName:
+    def test_known_int_role(self):
+        assert ia2.role_name(ia2.ROLE_LINK) == "link"
+        assert ia2.role_name(ia2.ROLE_PUSHBUTTON) == "button"
+        assert ia2.role_name(ia2.ROLE_STATICTEXT) == "text"
+        assert ia2.role_name(ia2.ROLE_LISTITEM) == "list item"
+
+    def test_unknown_int_role(self):
+        assert ia2.role_name(0xDEADBEEF) == "unknown"
+
+    def test_bstr_role_passes_through(self):
+        # Firefox can return BSTR roles like "heading", "article" for IA2 extensions.
+        assert ia2.role_name("heading") == "heading"
+        assert ia2.role_name("ARTICLE") == "article"
+        assert ia2.role_name("  paragraph  ") == "paragraph"
+
+    def test_empty_bstr_role(self):
+        assert ia2.role_name("") == "unknown"
+        assert ia2.role_name("   ") == "unknown"
+
+    def test_none_or_other_returns_unknown(self):
+        assert ia2.role_name(None) == "unknown"
+        assert ia2.role_name(3.14) == "unknown"
+
+
+class TestIsVisible:
+    def test_visible_element(self):
+        assert ia2._is_visible(state=0, location=(0, 0, 100, 50)) is True
+
+    def test_invisible_state(self):
+        assert ia2._is_visible(ia2.STATE_SYSTEM_INVISIBLE, (0, 0, 100, 50)) is False
+
+    def test_offscreen_state(self):
+        assert ia2._is_visible(ia2.STATE_SYSTEM_OFFSCREEN, (0, 0, 100, 50)) is False
+
+    def test_invisible_or_offscreen_combined(self):
+        combined = ia2.STATE_SYSTEM_INVISIBLE | ia2.STATE_SYSTEM_OFFSCREEN
+        assert ia2._is_visible(combined, (0, 0, 100, 50)) is False
+
+    def test_zero_size(self):
+        assert ia2._is_visible(0, (0, 0, 0, 50)) is False
+        assert ia2._is_visible(0, (0, 0, 100, 0)) is False
+
+    def test_no_location(self):
+        assert ia2._is_visible(0, None) is False
+
+    def test_focused_visible_element(self):
+        focused = ia2.STATE_SYSTEM_FOCUSED | ia2.STATE_SYSTEM_FOCUSABLE
+        assert ia2._is_visible(focused, (10, 10, 50, 50)) is True
+
+
+class TestBoundingBoxFromLocation:
+    def test_fully_inside_clip(self):
+        clip = BoundingBox(left=0, top=0, right=200, bottom=200, width=200, height=200)
+        bb = ia2._bounding_box_from_location((50, 50, 100, 100), clip)
+        assert (bb.left, bb.top, bb.right, bb.bottom) == (50, 50, 150, 150)
+        assert (bb.width, bb.height) == (100, 100)
+
+    def test_clipped_to_window(self):
+        clip = BoundingBox(left=10, top=10, right=100, bottom=100, width=90, height=90)
+        bb = ia2._bounding_box_from_location((-50, -50, 200, 200), clip)
+        assert (bb.left, bb.top, bb.right, bb.bottom) == (10, 10, 100, 100)
+        assert (bb.width, bb.height) == (90, 90)
+
+    def test_no_clip(self):
+        bb = ia2._bounding_box_from_location((10, 20, 30, 40), None)
+        assert (bb.left, bb.top, bb.right, bb.bottom) == (10, 20, 40, 60)
+        assert (bb.width, bb.height) == (30, 40)
+
+    def test_non_overlapping_clip(self):
+        clip = BoundingBox(left=0, top=0, right=100, bottom=100, width=100, height=100)
+        bb = ia2._bounding_box_from_location((500, 500, 50, 50), clip)
+        assert bb.width == 0 and bb.height == 0
+
+
+class TestRoleClassification:
+    def test_interactive_roles_contains_expected(self):
+        for role in (
+            ia2.ROLE_LINK,
+            ia2.ROLE_PUSHBUTTON,
+            ia2.ROLE_CHECKBUTTON,
+            ia2.ROLE_RADIOBUTTON,
+        ):
+            assert role in ia2.INTERACTIVE_ROLES
+
+    def test_informative_roles_contains_text(self):
+        assert ia2.ROLE_STATICTEXT in ia2.INFORMATIVE_ROLES
+        assert ia2.ROLE_TEXT in ia2.INFORMATIVE_ROLES
+
+    def test_disjoint_role_sets(self):
+        assert not (ia2.INTERACTIVE_ROLES & ia2.INFORMATIVE_ROLES)
+
+
+class TestWalkerRecord:
+    def _build_walker(self):
+        clip = BoundingBox(left=0, top=0, right=1000, bottom=1000, width=1000, height=1000)
+        return ia2._Walker(window_name="Firefox", dom_clip=clip)
+
+    def test_static_text_becomes_informative(self, monkeypatch):
+        walker = self._build_walker()
+        iacc = MagicMock()
+
+        monkeypatch.setattr(ia2, "_acc_name", lambda _: "hello world")
+        walker._record(iacc, role=ia2.ROLE_STATICTEXT, state=0, location=(0, 0, 100, 20))
+
+        assert len(walker.informative) == 1
+        assert isinstance(walker.informative[0], TextElementNode)
+        assert walker.informative[0].text == "hello world"
+        assert walker.interactive == []
+
+    def test_link_becomes_interactive(self, monkeypatch):
+        walker = self._build_walker()
+        iacc = MagicMock()
+
+        monkeypatch.setattr(ia2, "_acc_name", lambda _: "Click me")
+        monkeypatch.setattr(ia2, "_acc_value", lambda _: "https://example.com")
+        walker._record(iacc, role=ia2.ROLE_LINK, state=0, location=(10, 20, 80, 16))
+
+        assert len(walker.interactive) == 1
+        node = walker.interactive[0]
+        assert isinstance(node, TreeElementNode)
+        assert node.name == "Click me"
+        assert node.control_type.lower() == "link"
+        assert node.metadata["url"] == "https://example.com"
+        assert node.metadata["has_focused"] is False
+        assert walker.informative == []
+
+    def test_button_with_focus(self, monkeypatch):
+        walker = self._build_walker()
+        iacc = MagicMock()
+
+        monkeypatch.setattr(ia2, "_acc_name", lambda _: "Submit")
+        monkeypatch.setattr(ia2, "_acc_value", lambda _: "")
+        state = ia2.STATE_SYSTEM_FOCUSED | ia2.STATE_SYSTEM_FOCUSABLE
+        walker._record(iacc, role=ia2.ROLE_PUSHBUTTON, state=state, location=(0, 0, 80, 30))
+
+        assert len(walker.interactive) == 1
+        assert walker.interactive[0].metadata["has_focused"] is True
+
+    def test_graphic_with_alt_text_becomes_informative(self, monkeypatch):
+        walker = self._build_walker()
+        iacc = MagicMock()
+
+        monkeypatch.setattr(ia2, "_acc_name", lambda _: "Company logo")
+        walker._record(iacc, role=ia2.ROLE_GRAPHIC, state=0, location=(0, 0, 100, 100))
+
+        assert walker.interactive == []
+        assert len(walker.informative) == 1
+        assert walker.informative[0].text == "Company logo"
+
+    def test_graphic_without_alt_is_skipped(self, monkeypatch):
+        walker = self._build_walker()
+        iacc = MagicMock()
+
+        monkeypatch.setattr(ia2, "_acc_name", lambda _: "")
+        walker._record(iacc, role=ia2.ROLE_GRAPHIC, state=0, location=(0, 0, 100, 100))
+
+        assert walker.informative == []
+        assert walker.interactive == []
+
+    def test_unknown_role_is_skipped(self, monkeypatch):
+        walker = self._build_walker()
+        iacc = MagicMock()
+
+        monkeypatch.setattr(ia2, "_acc_name", lambda _: "irrelevant")
+        monkeypatch.setattr(ia2, "_acc_value", lambda _: "")
+        walker._record(iacc, role=0xDEADBEEF, state=0, location=(0, 0, 100, 100))
+
+        assert walker.informative == []
+        assert walker.interactive == []
+
+    def test_link_with_no_visible_bbox_skipped(self, monkeypatch):
+        # Element location is outside the clip — clipped width/height go to zero.
+        clip = BoundingBox(left=0, top=0, right=100, bottom=100, width=100, height=100)
+        walker = ia2._Walker(window_name="Firefox", dom_clip=clip)
+        iacc = MagicMock()
+
+        monkeypatch.setattr(ia2, "_acc_name", lambda _: "Offscreen link")
+        monkeypatch.setattr(ia2, "_acc_value", lambda _: "https://x")
+        walker._record(iacc, role=ia2.ROLE_LINK, state=0, location=(500, 500, 80, 16))
+
+        assert walker.interactive == []
+
+
+class TestWalkerScoping:
+    """The walker must (1) prune invisible subtrees and (2) only record inside documents."""
+
+    def _make_iacc(self, role, state, location, name="", value="", children=()):
+        """Build a fake IAccessible node for walker traversal tests."""
+        node = MagicMock()
+        node._fake = {
+            "role": role,
+            "state": state,
+            "location": location,
+            "name": name,
+            "value": value,
+            "children": children,
+        }
+        return node
+
+    def _walk_with_fake_tree(self, root, walker, monkeypatch):
+        """Drive the walker against a tree of fake nodes (no COM)."""
+        monkeypatch.setattr(ia2, "_acc_role", lambda n: n._fake["role"])
+        monkeypatch.setattr(ia2, "_acc_state", lambda n: n._fake["state"])
+        monkeypatch.setattr(ia2, "_acc_location", lambda n: n._fake["location"])
+        monkeypatch.setattr(ia2, "_acc_name", lambda n: n._fake["name"])
+        monkeypatch.setattr(ia2, "_acc_value", lambda n: n._fake["value"])
+        monkeypatch.setattr(ia2, "_iter_children", lambda n, _iface: iter(n._fake["children"]))
+        walker.walk(root, iface=object(), depth=0)
+
+    def test_chrome_outside_document_not_recorded(self, monkeypatch):
+        """Toolbar button (outside any document) must be excluded."""
+        # window -> toolbar button (no document)
+        button = self._make_iacc(ia2.ROLE_PUSHBUTTON, 0, (0, 0, 50, 30), name="Reload")
+        root = self._make_iacc(0x10, 0, (0, 0, 1000, 800), children=[button])  # ROLE_PANE
+
+        walker = ia2._Walker(window_name="Firefox", dom_clip=None)
+        self._walk_with_fake_tree(root, walker, monkeypatch)
+
+        assert walker.interactive == []
+        assert walker.informative == []
+
+    def test_link_inside_document_recorded(self, monkeypatch):
+        """A link inside a ROLE_DOCUMENT subtree should be captured."""
+        link = self._make_iacc(
+            ia2.ROLE_LINK,
+            0,
+            (10, 100, 200, 20),
+            name="YouTube video title",
+            value="https://youtu.be/abc",
+        )
+        document = self._make_iacc(ia2.ROLE_DOCUMENT, 0, (0, 50, 1000, 700), children=[link])
+        root = self._make_iacc(0x10, 0, (0, 0, 1000, 800), children=[document])
+
+        walker = ia2._Walker(window_name="Firefox", dom_clip=None)
+        self._walk_with_fake_tree(root, walker, monkeypatch)
+
+        assert len(walker.interactive) == 1
+        assert walker.interactive[0].name == "YouTube video title"
+        assert walker.interactive[0].metadata["url"] == "https://youtu.be/abc"
+
+    def test_invisible_document_subtree_pruned(self, monkeypatch):
+        """An invisible document (inactive Firefox tab) and its children must be skipped entirely."""
+        # Gmail-tab content nested inside an INVISIBLE document — simulates an inactive tab.
+        inactive_link = self._make_iacc(
+            ia2.ROLE_LINK,
+            0,
+            (0, 0, 100, 20),
+            name="Inbox",
+            value="https://gmail",
+        )
+        inactive_doc = self._make_iacc(
+            ia2.ROLE_DOCUMENT,
+            ia2.STATE_SYSTEM_INVISIBLE,
+            (0, 50, 1000, 700),
+            children=[inactive_link],
+        )
+        # Active tab — visible document with its own link.
+        active_link = self._make_iacc(
+            ia2.ROLE_LINK,
+            0,
+            (0, 0, 100, 20),
+            name="Search result",
+            value="https://yt",
+        )
+        active_doc = self._make_iacc(
+            ia2.ROLE_DOCUMENT,
+            0,
+            (0, 50, 1000, 700),
+            children=[active_link],
+        )
+        root = self._make_iacc(
+            0x10,
+            0,
+            (0, 0, 1000, 800),
+            children=[inactive_doc, active_doc],
+        )
+
+        walker = ia2._Walker(window_name="Firefox", dom_clip=None)
+        self._walk_with_fake_tree(root, walker, monkeypatch)
+
+        # Inactive tab's link must not be captured; only the active tab's link.
+        names = [n.name for n in walker.interactive]
+        assert "Inbox" not in names
+        assert names == ["Search result"]
+
+    def test_offscreen_subtree_pruned(self, monkeypatch):
+        """An offscreen document subtree is treated the same as invisible."""
+        offscreen_link = self._make_iacc(
+            ia2.ROLE_LINK,
+            0,
+            (0, 0, 100, 20),
+            name="Hidden",
+            value="x",
+        )
+        offscreen_doc = self._make_iacc(
+            ia2.ROLE_DOCUMENT,
+            ia2.STATE_SYSTEM_OFFSCREEN,
+            (0, 50, 1000, 700),
+            children=[offscreen_link],
+        )
+        root = self._make_iacc(0x10, 0, (0, 0, 1000, 800), children=[offscreen_doc])
+
+        walker = ia2._Walker(window_name="Firefox", dom_clip=None)
+        self._walk_with_fake_tree(root, walker, monkeypatch)
+
+        assert walker.interactive == []
+
+    def test_active_document_box_captured(self, monkeypatch):
+        """The first visible document's bbox is stored as the DOM bounding box."""
+        text = self._make_iacc(ia2.ROLE_STATICTEXT, 0, (10, 60, 100, 20), name="hello")
+        document = self._make_iacc(ia2.ROLE_DOCUMENT, 0, (5, 55, 990, 700), children=[text])
+        root = self._make_iacc(0x10, 0, (0, 0, 1000, 800), children=[document])
+
+        walker = ia2._Walker(window_name="Firefox", dom_clip=None)
+        self._walk_with_fake_tree(root, walker, monkeypatch)
+
+        assert walker.active_document_box is not None
+        assert walker.active_document_box.left == 5
+        assert walker.active_document_box.top == 55
+        assert walker.active_document_box.width == 990
+        assert walker.active_document_box.height == 700
+
+    def test_deeply_nested_content_captured(self, monkeypatch):
+        """Content several levels deep inside a document still surfaces."""
+        text = self._make_iacc(ia2.ROLE_STATICTEXT, 0, (0, 0, 100, 20), name="leaf")
+        wrap3 = self._make_iacc(0x14, 0, (0, 0, 100, 20), children=[text])
+        wrap2 = self._make_iacc(0x14, 0, (0, 0, 100, 20), children=[wrap3])
+        wrap1 = self._make_iacc(0x14, 0, (0, 0, 100, 20), children=[wrap2])
+        document = self._make_iacc(ia2.ROLE_DOCUMENT, 0, (0, 50, 1000, 700), children=[wrap1])
+        root = self._make_iacc(0x10, 0, (0, 0, 1000, 800), children=[document])
+
+        walker = ia2._Walker(window_name="Firefox", dom_clip=None)
+        self._walk_with_fake_tree(root, walker, monkeypatch)
+
+        assert [n.text for n in walker.informative] == ["leaf"]
+
+
+class TestTraversalResult:
+    def test_truthiness_empty(self):
+        result = ia2.IA2TraversalResult(
+            dom_bounding_box=None, informative_nodes=[], interactive_nodes=[]
+        )
+        assert bool(result) is False
+
+    def test_truthiness_with_informative(self):
+        result = ia2.IA2TraversalResult(
+            dom_bounding_box=None,
+            informative_nodes=[TextElementNode(text="hi")],
+            interactive_nodes=[],
+        )
+        assert bool(result) is True
+
+    def test_truthiness_with_interactive(self):
+        bb = BoundingBox(left=0, top=0, right=10, bottom=10, width=10, height=10)
+        result = ia2.IA2TraversalResult(
+            dom_bounding_box=bb,
+            informative_nodes=[],
+            interactive_nodes=[
+                TreeElementNode(
+                    bounding_box=bb,
+                    center=bb.get_center(),
+                    name="X",
+                    control_type="link",
+                    window_name="Firefox",
+                )
+            ],
+        )
+        assert bool(result) is True
+
+
+def test_traverse_window_returns_empty_when_com_unavailable(monkeypatch):
+    """If AccessibleObjectFromWindow fails (e.g. no oleacc.dll), return an empty result."""
+
+    def _raise_os_error(_hwnd: int):
+        raise OSError("AccessibleObjectFromWindow failed: HRESULT=0x80004005")
+
+    monkeypatch.setattr(ia2, "_accessible_object_from_window", _raise_os_error)
+    monkeypatch.setattr(ia2, "_iaccessible", lambda: object)
+
+    bb = BoundingBox(left=0, top=0, right=10, bottom=10, width=10, height=10)
+    result = ia2.traverse_window(hwnd=0xABCD, window_name="Firefox", window_bounding_box=bb)
+    assert result.informative_nodes == []
+    assert result.interactive_nodes == []
+    assert result.dom_bounding_box == bb
+    assert bool(result) is False
+
+
+def test_traverse_window_returns_empty_when_runtime_error(monkeypatch):
+    """If AccessibleObjectFromWindow returns null, return an empty result."""
+
+    def _raise_runtime(_hwnd: int):
+        raise RuntimeError("AccessibleObjectFromWindow returned a null pointer")
+
+    monkeypatch.setattr(ia2, "_accessible_object_from_window", _raise_runtime)
+    monkeypatch.setattr(ia2, "_iaccessible", lambda: object)
+
+    result = ia2.traverse_window(hwnd=0, window_name="Firefox")
+    assert result.dom_bounding_box is None
+    assert result.informative_nodes == []
+    assert result.interactive_nodes == []


### PR DESCRIPTION
## Description

Adds IAccessible2 / MSAA support so `Scrape(use_dom=True)` and `Snapshot(use_dom=True)` work on Firefox.

## Motivation

Today `Scrape(use_dom=True)` only works on Chrome and Edge. The UIA traversal in `tree/service.py` looks for `AutomationId == "RootWebArea"` to enter "DOM mode" — that's the Chrome/Edge convention. Firefox exposes its browser chrome via UIA but its web DOM only through MSAA / IAccessible2, with no `RootWebArea` marker, so the traversal silently skips the DOM and Scrape returns *"No DOM information found. Please open <url> in browser first."* even when the URL is open in the active Firefox tab.

## Changes

- `src/windows_mcp/tree/ia2.py` *(new)* — self-contained IA / IA2 walker. Fetches the root accessible via `AccessibleObjectFromWindow` (oleacc.dll) and walks the resulting tree, collecting `TextElementNode` / `TreeElementNode` lists scoped to the active document's bounding box. Pure-Python helpers (role classification, visibility, clipping) are split from the COM-touching code so they can be unit-tested without a live Firefox.
- `src/windows_mcp/tree/service.py` — calls the new walker as a fallback in `get_window_wise_nodes` when `is_browser=True`, `use_dom=True`, and the UIA pass produced no `self.dom`. A stub `DocumentControl` `dom_node` is surfaced via a new `elif self.dom_is_ia2` branch so downstream consumers (Scrape) work transparently.
- `src/windows_mcp/tools/scrape.py` — tool description updated to mention Firefox.
- `tests/test_tree_ia2.py` *(new)* — 37 unit tests covering role mapping, visibility / offscreen filtering, bounding-box clipping, walker scoping (chrome vs document content), and traversal-result truthiness. Mocks `IAccessible` so they run on any platform.

## Performance

Measured ~230 ms for the IA2 walk on a real Firefox window with ~25 informative nodes. The fallback skips entirely for Chrome/Edge (UIA path stays primary) and for non-browser windows. Failures are logged at `WARNING` and don't break the snapshot.

> ``[Tree] IA2 fallback for 'Test Page — Mock YouTube Search Results — Mozilla Firefox' produced 0 interactive / 25 informative nodes in 229.8ms``

## Testing

- `pytest tests/test_tree_ia2.py` — **37 passed in 0.10s**
- Full suite — **267 passed**, plus the 6 pre-existing `test_tree_views.py` failures and the `test_analytics.py` collection error that reproduce on plain `origin/main`. No new regressions.
- Manual end-to-end against an offline mock YouTube fixture in Firefox: `Scrape(use_dom=True, use_sampling=False)` captured the visible result titles, did not leak content from an invisible background-tab div or sidebar chrome (tab-scoping intact), and the IA2 walker did not interfere with Chrome/Edge DOM extraction.

## Related Issues

None — opened as a feature contribution.