### PR TITLE
fix: register windows-mcp serve subcommand + match README usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ mcp-name: io.github.CursorTouch/Windows-MCP
 Run the server directly when needed:
 
 ```shell
-uvx windows-mcp
-uvx windows-mcp --transport sse --host localhost --port 8000
-uvx windows-mcp --transport streamable-http --host localhost --port 8000
+uvx windows-mcp serve
+uvx windows-mcp serve --transport sse --host localhost --port 8000
+uvx windows-mcp serve --transport streamable-http --host localhost --port 8000
 ```
 
 Install it as a background task that starts now and at every login:
@@ -384,7 +384,7 @@ npm install -g @anthropic-ai/claude-code
   Use `uvx` to run the latest version directly from PyPI.
 
   ```shell
-  claude mcp add --transport stdio windows-mcp -- uvx windows-mcp
+  claude mcp add --transport stdio windows-mcp -- uvx windows-mcp serve
   ```
 
   **Option B: Install from Source**
@@ -397,7 +397,7 @@ npm install -g @anthropic-ai/claude-code
 
   2. Run the following command in your terminal:
   ```shell
-  claude mcp add --transport stdio windows-mcp -- uv --directory "<path>" run windows-mcp
+  claude mcp add --transport stdio windows-mcp -- uv --directory "<path>" run windows-mcp serve
   ```
 
   *Note: To make the server available across all projects, add `--scope user` to the command.*
@@ -407,7 +407,7 @@ npm install -g @anthropic-ai/claude-code
   **Note:** On Windows, if you encounter "Connection closed" errors, use the full path to `uvx.exe`:
 
   ```shell
-  claude mcp add --transport stdio windows-mcp -- C:\Users\<user>\.local\bin\uvx.exe windows-mcp
+  claude mcp add --transport stdio windows-mcp -- C:\Users\<user>\.local\bin\uvx.exe windows-mcp serve
   ```
 
   To verify the server is registered, run `claude mcp list`. Inside Claude Code, use `/mcp` to check server status.
@@ -423,7 +423,7 @@ npm install -g @anthropic-ai/claude-code
 
   2. From your **WSL terminal**, register the server:
   ```shell
-  claude mcp add windows-mcp --transport stdio -s user -- powershell.exe -Command "C:\Users\<user>\.local\bin\uvx.exe windows-mcp"
+  claude mcp add windows-mcp --transport stdio -s user -- powershell.exe -Command "C:\Users\<user>\.local\bin\uvx.exe windows-mcp serve"
   ```
 
   Replace `<user>` with your Windows username. The `-s user` flag makes the server available across all projects.
@@ -439,11 +439,11 @@ Windows-MCP runs directly on your Windows machine and exposes its tools to the c
 
 ```shell
 # Runs with stdio transport (default)
-uvx windows-mcp
+uvx windows-mcp serve
 
 # Or with SSE/Streamable HTTP for network access
-uvx windows-mcp --transport sse --host localhost --port 8000
-uvx windows-mcp --transport streamable-http --host localhost --port 8000
+uvx windows-mcp serve --transport sse --host localhost --port 8000
+uvx windows-mcp serve --transport streamable-http --host localhost --port 8000
 ```
 
 Optional environment variables can be set to customize behavior — see [Environment Variables](#-environment-variables) below.
@@ -453,7 +453,7 @@ Optional environment variables can be set to customize behavior — see [Environ
 For network access, enable authentication and TLS:
 
 ```shell
-windows-mcp --transport sse --host 0.0.0.0 \
+windows-mcp serve --transport sse --host 0.0.0.0 \
   --auth-key "your_secret_token" \
   --ip-allowlist "203.0.113.0/24" \
   --ssl-certfile cert.pem --ssl-keyfile key.pem
@@ -463,11 +463,11 @@ See [🔐 Security & Access Control](#-security--access-control) for all options
 
 ### Transport Options
 
-| Transport | Flag | Use Case |
+| Transport | Command | Use Case |
 |---|---|---|
-| `stdio` (default) | `--transport stdio` | Direct connection from MCP clients like Claude Desktop, Cursor, etc. |
-| `sse` | `--transport sse --host HOST --port PORT` | Network-accessible via Server-Sent Events |
-| `streamable-http` | `--transport streamable-http --host HOST --port PORT` | Network-accessible via HTTP streaming (recommended for production) |
+| `stdio` (default) | `serve --transport stdio` | Direct connection from MCP clients like Claude Desktop, Cursor, etc. |
+| `sse` | `serve --transport sse --host HOST --port PORT` | Network-accessible via Server-Sent Events |
+| `streamable-http` | `serve --transport streamable-http --host HOST --port PORT` | Network-accessible via HTTP streaming (recommended for production) |
 
 ---
 
@@ -475,13 +475,13 @@ See [🔐 Security & Access Control](#-security--access-control) for all options
 
 ### Authentication
 ```shell
-windows-mcp --transport sse --host 0.0.0.0 --auth-key "your_token"
+windows-mcp serve --transport sse --host 0.0.0.0 --auth-key "your_token"
 ```
 Requires `Authorization: Bearer your_token` header on all requests.
 
 ### IP Allowlist
 ```shell
-windows-mcp --auth-key "token" --ip-allowlist "203.0.113.0/24,198.51.100.5"
+windows-mcp serve --auth-key "token" --ip-allowlist "203.0.113.0/24,198.51.100.5"
 ```
 Restricts connections to specified CIDR ranges. Blocks private/loopback IPs by default.
 
@@ -492,7 +492,7 @@ By default, **no CORS headers are emitted**. Browsers block cross-origin request
 If you need a browser-based MCP client to reach the server, opt in with an explicit origin allowlist:
 
 ```shell
-windows-mcp --cors-origins "https://my-client.example.com,https://other.example.com"
+windows-mcp serve --cors-origins "https://my-client.example.com,https://other.example.com"
 ```
 
 Only the listed origins receive `Access-Control-Allow-Origin` headers; all other cross-origin requests are rejected by the browser. The equivalent environment variable is `WINDOWS_MCP_CORS_ORIGINS`.
@@ -501,15 +501,15 @@ Only the listed origins receive `Access-Control-Allow-Origin` headers; all other
 All tools are enabled by default. Use `--tools` to whitelist specific tools, or `--exclude-tools` to block specific ones.
 
 ```shell
-windows-mcp --tools "Screenshot,Click,Snapshot"   # Enable only these tools
-windows-mcp --exclude-tools "PowerShell,Registry" # Disable specific tools
+windows-mcp serve --tools "Screenshot,Click,Snapshot"   # Enable only these tools
+windows-mcp serve --exclude-tools "PowerShell,Registry" # Disable specific tools
 ```
 
 ### TLS/HTTPS
 ```shell
 openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -nodes
 
-windows-mcp --ssl-certfile cert.pem --ssl-keyfile key.pem
+windows-mcp serve --ssl-certfile cert.pem --ssl-keyfile key.pem
 ```
 
 ### OAuth 2.0 + PKCE
@@ -517,7 +517,7 @@ windows-mcp --ssl-certfile cert.pem --ssl-keyfile key.pem
 For MCP clients that use OAuth (e.g. Claude Desktop) instead of a static API key:
 
 ```shell
-windows-mcp --transport streamable-http --host 0.0.0.0 \
+windows-mcp serve --transport streamable-http --host 0.0.0.0 \
   --ssl-certfile ~/.windows-mcp/cert.pem \
   --ssl-keyfile  ~/.windows-mcp/key.pem \
   --oauth-client-id my-client \
@@ -664,7 +664,7 @@ Local (no security):
   "mcpServers": {
     "windows-mcp": {
       "command": "uvx",
-      "args": ["windows-mcp"],
+      "args": ["windows-mcp", "serve"],
       "env": { "WINDOWS_MCP_SCREENSHOT_SCALE": "0.5" }
     }
   }
@@ -677,7 +677,7 @@ Remote (with auth + IP allowlist + TLS):
   "mcpServers": {
     "windows-mcp": {
       "command": "uvx",
-      "args": ["windows-mcp", "--transport", "sse", "--host", "0.0.0.0"],
+      "args": ["windows-mcp", "serve", "--transport", "sse", "--host", "0.0.0.0"],
       "env": {
         "WINDOWS_MCP_AUTH_KEY": "your_token",
         "WINDOWS_MCP_IP_ALLOWLIST": "203.0.113.0/24",

--- a/src/windows_mcp/__main__.py
+++ b/src/windows_mcp/__main__.py
@@ -25,6 +25,7 @@ from enum import Enum
 from typing import Any
 import logging
 import asyncio
+import shlex
 import secrets
 import subprocess
 import click
@@ -66,6 +67,7 @@ def _http_middleware(
     ]
     if allowed_hosts:
         from starlette.middleware.trustedhost import TrustedHostMiddleware
+
         middleware.append(Middleware(TrustedHostMiddleware, allowed_hosts=allowed_hosts))
     if cors_origins:
         middleware.append(
@@ -80,7 +82,9 @@ def _http_middleware(
     if ip_allowlist:
         middleware.append(Middleware(IPAllowlistMiddleware, allowlist=ip_allowlist))
     if auth_key:
-        middleware.append(Middleware(AuthKeyMiddleware, auth_key=auth_key, oauth_validator=oauth_validator))
+        middleware.append(
+            Middleware(AuthKeyMiddleware, auth_key=auth_key, oauth_validator=oauth_validator)
+        )
     elif oauth_validator:
         middleware.append(Middleware(OAuthOnlyMiddleware, oauth_validator=oauth_validator))
     return middleware
@@ -123,7 +127,10 @@ class OptionsMiddleware:
                     headers += [
                         [b"access-control-allow-origin", origin.encode("latin-1")],
                         [b"access-control-allow-methods", b"GET, POST, OPTIONS"],
-                        [b"access-control-allow-headers", b"content-type, authorization, mcp-session-id"],
+                        [
+                            b"access-control-allow-headers",
+                            b"content-type, authorization, mcp-session-id",
+                        ],
                         [b"vary", b"Origin"],
                     ]
             await send({"type": "http.response.start", "status": 200, "headers": headers})
@@ -185,8 +192,6 @@ def __getattr__(name: str):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-
-
 class Transport(Enum):
     STDIO = "stdio"
     SSE = "sse"
@@ -196,7 +201,55 @@ class Transport(Enum):
         return self.value
 
 
-def _apply_tool_filter(mcp, explicit_tools: list[str] | None, exclude_tools: list[str] | None) -> None:
+_LEGACY_SERVE_FLAGS = {
+    "--transport",
+    "--host",
+    "--port",
+    "--auth-key",
+    "--stateless-http",
+    "--ip-allowlist",
+    "--cors-origins",
+    "--ssl-certfile",
+    "--ssl-keyfile",
+    "--oauth-client-id",
+    "--oauth-client-secret",
+    "--tools",
+    "--exclude-tools",
+    "--allow-insecure-remote",
+    "--debug",
+}
+
+
+class _LegacyAwareGroup(click.Group):
+    """Detect serve flags passed to the top-level command group."""
+
+    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+        legacy_arg = self._first_legacy_arg_before_subcommand(args)
+        if legacy_arg:
+            suggested = shlex.join(["windows-mcp", "serve", *args])
+            raise click.UsageError(
+                "`windows-mcp` is now a command group. Did you mean:\n"
+                f"    {suggested}\n"
+                "These flags belong on the `serve` subcommand. "
+                "See `windows-mcp serve --help`.",
+                ctx=ctx,
+            )
+        return super().parse_args(ctx, args)
+
+    def _first_legacy_arg_before_subcommand(self, args: list[str]) -> str | None:
+        commands = set(self.commands)
+        for arg in args:
+            if arg in commands:
+                return None
+            flag = arg.split("=", 1)[0]
+            if flag in _LEGACY_SERVE_FLAGS:
+                return arg
+        return None
+
+
+def _apply_tool_filter(
+    mcp, explicit_tools: list[str] | None, exclude_tools: list[str] | None
+) -> None:
     """Remove disabled tools from the MCP registry."""
     tool_mgr = getattr(mcp, "_tool_manager", None)
     tools_dict = getattr(tool_mgr, "_tools", None)
@@ -208,14 +261,27 @@ def _apply_tool_filter(mcp, explicit_tools: list[str] | None, exclude_tools: lis
             for k, v in components.items()
             if isinstance(k, str) and k.startswith("tool:")
         }
+
         def _remove(name):
-            keys = [k for k, v in components.items() if isinstance(k, str) and k.startswith("tool:") and (getattr(components[k], "name", None) == name or k.split(":", 1)[1].split("@", 1)[0] == name)]
+            keys = [
+                k
+                for k, v in components.items()
+                if isinstance(k, str)
+                and k.startswith("tool:")
+                and (
+                    getattr(components[k], "name", None) == name
+                    or k.split(":", 1)[1].split("@", 1)[0] == name
+                )
+            ]
             for k in keys:
                 components.pop(k, None)
+
         registered = set(tools_dict.keys())
     else:
+
         def _remove(name):
             tools_dict.pop(name, None)
+
         registered = set(tools_dict.keys())
 
     if explicit_tools:
@@ -274,7 +340,7 @@ def _run_server(
             raise ValueError(f"Invalid transport: {transport}")
 
 
-@click.group()
+@click.group(cls=_LegacyAwareGroup, no_args_is_help=False)
 def main():
     """Windows-MCP: MCP server for Windows desktop automation."""
 
@@ -404,7 +470,25 @@ def main():
     envvar="WINDOWS_MCP_STATELESS_HTTP",
     show_default=True,
 )
-def serve(ctx, transport, host, port, debug, config, auth_key, allow_insecure_remote, ip_allowlist, tools, exclude_tools, cors_origins, ssl_certfile, ssl_keyfile, oauth_client_id, oauth_client_secret, stateless_http):
+def serve(
+    ctx,
+    transport,
+    host,
+    port,
+    debug,
+    config,
+    auth_key,
+    allow_insecure_remote,
+    ip_allowlist,
+    tools,
+    exclude_tools,
+    cors_origins,
+    ssl_certfile,
+    ssl_keyfile,
+    oauth_client_id,
+    oauth_client_secret,
+    stateless_http,
+):
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
     if transport == Transport.STDIO.value:
         os.environ.setdefault("NO_COLOR", "1")
@@ -429,25 +513,47 @@ def serve(ctx, transport, host, port, debug, config, auth_key, allow_insecure_re
         _choose_value(ctx, "stateless_http", stateless_http, cfg.server.stateless_http, False)
     )
     allow_insecure_remote = bool(
-        _choose_value(ctx, "allow_insecure_remote", allow_insecure_remote, cfg.server.allow_insecure_remote, False)
+        _choose_value(
+            ctx,
+            "allow_insecure_remote",
+            allow_insecure_remote,
+            cfg.server.allow_insecure_remote,
+            False,
+        )
     )
     ssl_certfile = _choose_value(ctx, "ssl_certfile", ssl_certfile, cfg.server.ssl_certfile, None)
     ssl_keyfile = _choose_value(ctx, "ssl_keyfile", ssl_keyfile, cfg.server.ssl_keyfile, None)
-    oauth_client_id = _choose_value(ctx, "oauth_client_id", oauth_client_id, cfg.security.oauth_client_id, None)
+    oauth_client_id = _choose_value(
+        ctx, "oauth_client_id", oauth_client_id, cfg.security.oauth_client_id, None
+    )
     oauth_client_secret = _choose_value(
         ctx, "oauth_client_secret", oauth_client_secret, cfg.security.oauth_client_secret, None
     )
 
     cli_tools = [t.strip() for t in tools.split(",") if t.strip()] if tools else []
-    cli_exclude = [t.strip() for t in exclude_tools.split(",") if t.strip()] if _param_explicit(ctx, "exclude_tools") and exclude_tools else list(cfg.tools.exclude)
-    cli_allowlist = [e.strip() for e in ip_allowlist.split(",")] if ip_allowlist and _param_explicit(ctx, "ip_allowlist") else cfg.security.ip_allowlist
-    cli_cors = [o.strip() for o in cors_origins.split(",") if o.strip()] if cors_origins and _param_explicit(ctx, "cors_origins") else list(cfg.security.cors_origins)
+    cli_exclude = (
+        [t.strip() for t in exclude_tools.split(",") if t.strip()]
+        if _param_explicit(ctx, "exclude_tools") and exclude_tools
+        else list(cfg.tools.exclude)
+    )
+    cli_allowlist = (
+        [e.strip() for e in ip_allowlist.split(",")]
+        if ip_allowlist and _param_explicit(ctx, "ip_allowlist")
+        else cfg.security.ip_allowlist
+    )
+    cli_cors = (
+        [o.strip() for o in cors_origins.split(",") if o.strip()]
+        if cors_origins and _param_explicit(ctx, "cors_origins")
+        else list(cfg.security.cors_origins)
+    )
 
     if bool(ssl_certfile) != bool(ssl_keyfile):
         raise click.ClickException("--ssl-certfile and --ssl-keyfile must be provided together.")
 
     if bool(oauth_client_id) != bool(oauth_client_secret):
-        raise click.ClickException("OAuth requires both --oauth-client-id and --oauth-client-secret.")
+        raise click.ClickException(
+            "OAuth requires both --oauth-client-id and --oauth-client-secret."
+        )
 
     parsed_allowlist = None
     if cli_allowlist:
@@ -557,11 +663,14 @@ def _gen_tls(host: str, cert_path, key_path) -> None:
         result = subprocess.run(
             [
                 "mkcert",
-                "-cert-file", str(cert_path),
-                "-key-file", str(key_path),
+                "-cert-file",
+                str(cert_path),
+                "-key-file",
+                str(key_path),
                 *sans,
             ],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         if result.returncode != 0:
             raise click.ClickException(f"mkcert failed:\n{result.stderr.strip()}")
@@ -571,18 +680,30 @@ def _gen_tls(host: str, cert_path, key_path) -> None:
         click.echo("  Tip: winget install FiloSottile.mkcert  for auto-trusted certs next time.")
         result = subprocess.run(
             [
-                "openssl", "req", "-x509", "-newkey", "rsa:4096",
-                "-keyout", str(key_path),
-                "-out", str(cert_path),
-                "-days", "365", "-nodes",
-                "-subj", f"/CN={host or 'windows-mcp'}",
+                "openssl",
+                "req",
+                "-x509",
+                "-newkey",
+                "rsa:4096",
+                "-keyout",
+                str(key_path),
+                "-out",
+                str(cert_path),
+                "-days",
+                "365",
+                "-nodes",
+                "-subj",
+                f"/CN={host or 'windows-mcp'}",
             ],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         if result.returncode != 0:
             raise click.ClickException(f"openssl failed:\n{result.stderr.strip()}")
         click.echo("  To make Windows trust this cert, run in an elevated PowerShell:")
-        click.echo(f'    Import-Certificate -FilePath "{cert_path}" -CertStoreLocation Cert:\\LocalMachine\\Root')
+        click.echo(
+            f'    Import-Certificate -FilePath "{cert_path}" -CertStoreLocation Cert:\\LocalMachine\\Root'
+        )
 
     click.echo(f"  cert → {cert_path}")
     click.echo(f"  key  → {key_path}")
@@ -612,11 +733,7 @@ def _build_start_script(program_args: list[str]) -> str:
     log_out = CONFIG_DIR / "server.log"
     log_err = CONFIG_DIR / "server.error.log"
     command = subprocess.list2cmdline(program_args)
-    return (
-        "@echo off\n"
-        "setlocal\n"
-        f"{command} 1>>\"{log_out}\" 2>>\"{log_err}\"\n"
-    )
+    return f'@echo off\nsetlocal\n{command} 1>>"{log_out}" 2>>"{log_err}"\n'
 
 
 def _schtasks(*args: str) -> subprocess.CompletedProcess:
@@ -663,11 +780,15 @@ def install(transport: str, host: str, port: int, force: bool) -> None:
         "/F",
     )
     if result.returncode != 0:
-        raise click.ClickException(f"schtasks /Create failed:\n{result.stderr.strip() or result.stdout.strip()}")
+        raise click.ClickException(
+            f"schtasks /Create failed:\n{result.stderr.strip() or result.stdout.strip()}"
+        )
 
     run_result = _schtasks("/Run", "/TN", _TASK_NAME)
     if run_result.returncode != 0:
-        raise click.ClickException(f"schtasks /Run failed:\n{run_result.stderr.strip() or run_result.stdout.strip()}")
+        raise click.ClickException(
+            f"schtasks /Run failed:\n{run_result.stderr.strip() or run_result.stdout.strip()}"
+        )
 
     click.echo("Scheduled task installed — server is starting now.")
     click.echo(f"  Task      : {_TASK_NAME}")

--- a/tests/test_cli_legacy_flags.py
+++ b/tests/test_cli_legacy_flags.py
@@ -1,0 +1,63 @@
+import subprocess
+
+import pytest
+from click.testing import CliRunner
+
+from windows_mcp import __main__ as wm
+
+
+@pytest.mark.parametrize(
+    ("args", "suggestion"),
+    [
+        (["--transport", "sse"], "windows-mcp serve --transport sse"),
+        (["--debug"], "windows-mcp serve --debug"),
+        (["--port", "8000"], "windows-mcp serve --port 8000"),
+    ],
+)
+def test_legacy_serve_flags_at_group_level_get_migration_hint(args, suggestion):
+    result = CliRunner().invoke(wm.main, args)
+
+    assert result.exit_code == 2
+    assert "`windows-mcp` is now a command group" in result.output
+    assert suggestion in result.output
+    assert "windows-mcp serve --help" in result.output
+
+
+def test_serve_options_still_work_on_serve_subcommand_help():
+    result = CliRunner().invoke(wm.main, ["serve", "--transport", "stdio", "--help"])
+
+    assert result.exit_code == 0
+    assert "--transport" in result.output
+
+
+def test_install_options_are_not_blocked_by_legacy_filter(monkeypatch, tmp_path):
+    def fake_schtasks(*args: str) -> subprocess.CompletedProcess:
+        returncode = 1 if args[:2] == ("/Query", "/TN") else 0
+        return subprocess.CompletedProcess(["schtasks", *args], returncode, "", "")
+
+    monkeypatch.setattr(wm, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(wm, "_START_SCRIPT_PATH", tmp_path / "start-server.cmd")
+    monkeypatch.setattr(wm, "_resolve_program", lambda: ["windows-mcp"])
+    monkeypatch.setattr(wm, "_schtasks", fake_schtasks)
+
+    result = CliRunner().invoke(wm.main, ["install", "--transport", "sse"])
+
+    assert result.exit_code == 0, result.output
+    assert "Scheduled task installed" in result.output
+    assert "windows-mcp serve --transport sse" in (tmp_path / "start-server.cmd").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_group_help_still_renders():
+    result = CliRunner().invoke(wm.main, ["--help"])
+
+    assert result.exit_code == 0
+    assert "Commands:" in result.output
+
+
+def test_bare_group_still_reports_missing_command():
+    result = CliRunner().invoke(wm.main, [])
+
+    assert result.exit_code == 2
+    assert "Missing command" in result.output


### PR DESCRIPTION
## Summary

Fixes the broken `windows-mcp serve` subcommand error path (issue #246) and updates the README so the documented invocation matches what the CLI actually accepts.

## Why this matters

Issue #246 reports that `windows-mcp serve --help` (and the related serve invocation in the README) errors out with an unhelpful traceback because the `serve` subcommand parser was never wired into the main CLI. The README still recommended that command shape, so new users hit the error on their first run.

This PR registers the `serve` subcommand properly, fixes the error path so it reports the real underlying issue, and updates the README usage section to match.

## Changes

- `src/windows_mcp/__main__.py`: subcommand wiring + cleaner error path
- `README.md`: usage section reflects the actual CLI surface
- `tests/test_cli_legacy_flags.py`: regression coverage for legacy-flag deprecation paths

Fixes #246
