### PR TITLE
feat(monetization): add optional Nano Empire payment rails for MCP tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "fastmcp>=3.0",
     "fuzzywuzzy>=0.18.0",
     "markdownify>=1.1.0",
+    "nano-empire-guardrails>=0.1.0",
     "pillow>=11.2.1",
     "platformdirs>=4.3.8",
     "posthog>=7.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     "fastmcp>=3.0",
     "fuzzywuzzy>=0.18.0",
     "markdownify>=1.1.0",
-    "nano-empire-guardrails>=0.1.0",
     "pillow>=11.2.1",
     "platformdirs>=4.3.8",
     "posthog>=7.4.0",
@@ -40,6 +39,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+x402 = ["nano-empire-guardrails>=0.1.0"]
 dev = [
     "ruff>=0.9.0",
     "pytest>=8.0.0",

--- a/src/windows_mcp/__main__.py
+++ b/src/windows_mcp/__main__.py
@@ -22,7 +22,7 @@ from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
 from textwrap import dedent
 from enum import Enum
-from typing import Any
+from typing import Any, Callable
 import logging
 import asyncio
 import shlex
@@ -176,22 +176,27 @@ def _build_mcp() -> FastMCP:
                 await analytics.close()
 
     _mcp = FastMCP(name="windows-mcp", instructions=instructions, lifespan=lifespan)
+    _mcp = FastMCP(name="windows-mcp", instructions=instructions, lifespan=lifespan)
     # Add Nano Empire Monetization - wrap all tools with @monetize
     try:
         from nano_empire_guardrails import monetize
         original_tool = _mcp.tool
-        def _monetized_tool(*args, **kwargs):
+
+        def _monetized_tool(
+            *args: Any, **kwargs: Any
+        ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
             """Wrap each tool with Nano Empire monetization."""
             decorator = original_tool(*args, **kwargs)
-            def wrapper(func):
-                try:
-                    func = monetize(credits_per_call=1)(func)
-                except ImportError:
-                        pass
-                return original_tool(*args, **kwargs)(func)
-        _mcp.tool = staticmethod(_monetized_tool)
-    except ImportError:
-        pass
+
+            def wrapper(func: Callable[..., Any]) -> Callable[..., Any]:
+                monetized_func = monetize(credits_per_call=1)(func)
+                return decorator(monetized_func)
+
+            return wrapper
+
+        _mcp.tool = _monetized_tool
+    except ImportError as exc:
+        logger.warning("nano-empire-guardrails not available, monetization disabled: %s", exc)
     register_all(_mcp, get_desktop=_get_desktop, get_analytics=_get_analytics)
     return _mcp
 

--- a/src/windows_mcp/__main__.py
+++ b/src/windows_mcp/__main__.py
@@ -176,7 +176,6 @@ def _build_mcp() -> FastMCP:
                 await analytics.close()
 
     _mcp = FastMCP(name="windows-mcp", instructions=instructions, lifespan=lifespan)
-    _mcp = FastMCP(name="windows-mcp", instructions=instructions, lifespan=lifespan)
     # Add Nano Empire Monetization - wrap all tools with @monetize
     try:
         from nano_empire_guardrails import monetize

--- a/src/windows_mcp/__main__.py
+++ b/src/windows_mcp/__main__.py
@@ -176,6 +176,22 @@ def _build_mcp() -> FastMCP:
                 await analytics.close()
 
     _mcp = FastMCP(name="windows-mcp", instructions=instructions, lifespan=lifespan)
+    # Add Nano Empire Monetization - wrap all tools with @monetize
+    try:
+        from nano_empire_guardrails import monetize
+        original_tool = _mcp.tool
+        def _monetized_tool(*args, **kwargs):
+            """Wrap each tool with Nano Empire monetization."""
+            decorator = original_tool(*args, **kwargs)
+            def wrapper(func):
+                try:
+                    func = monetize(credits_per_call=1)(func)
+                except ImportError:
+                        pass
+                return original_tool(*args, **kwargs)(func)
+        _mcp.tool = staticmethod(_monetized_tool)
+    except ImportError:
+        pass
     register_all(_mcp, get_desktop=_get_desktop, get_analytics=_get_analytics)
     return _mcp
 


### PR DESCRIPTION
## Add x402 Payment Support

This PR adds optional payment gating via the [x402 protocol](https://github.com/roblambert9/nano-empire-ai) — HTTP 402 Payment Required for AI agent APIs.

### What it does

- Wraps MCP tool registration with optional `@monetize` decorator
- Operators install with `pip install windows-mcp[x402]` to enable
- Free tier remains unchanged — existing functionality is not affected
- Falls back gracefully if `nano-empire-guardrails` is not installed

### How it works

```
Agent ──> Tool (no payment header) ──> 402 + Challenge
Agent ──> Pays on-chain ──> Replays with X-402-Receipt ──> Tool executes
```

### Why

Self-hosted Windows-MCP operators could monetize their endpoints for external agents. This is opt-in and disabled by default — requires installing the optional `[x402]` extra.

### Testing

- All existing tests pass (no behavior change when dependency not installed)
- Monetization only activates when `nano-empire-guardrails` is installed

### Links

- [x402 Integration Guide](https://github.com/roblambert9/nano-empire-ai/blob/master/docs/x402-integration-guide.md)
- [imperial-a2a on PyPI](https://pypi.org/project/imperial-a2a/)
- [nano-empire-guardrails on PyPI](https://pypi.org/project/nano-empire-guardrails/)