### PR TITLE
fix: guard desktop_state null crash in switch_app/resize_app; fix click default

### DIFF
--- a/src/desktop/service.py
+++ b/src/desktop/service.py
@@ -139,6 +139,8 @@ class Desktop:
         return "".join([row.get('DisplayName') for row in reader])
     
     def resize_app(self,size:tuple[int,int]=None,loc:tuple[int,int]=None)->tuple[str,int]:
+        if self.desktop_state is None:
+            self.get_state()
         active_app=self.desktop_state.active_app
         if active_app is None:
             return "No active app found",1
@@ -208,6 +210,8 @@ class Desktop:
         return response,status
     
     def switch_app(self,name:str):
+        if self.desktop_state is None:
+            self.get_state()
         apps={app.name:app for app in [self.desktop_state.active_app]+self.desktop_state.apps if app is not None}
         matched_app:Optional[tuple[str,float]]=process.extractOne(name,list(apps.keys()),score_cutoff=70)
         if matched_app is None:
@@ -250,7 +254,7 @@ class Desktop:
         bounding_rectangle=element_handle.BoundingRectangle
         return bounding_rectangle.xcenter(),bounding_rectangle.ycenter()
         
-    def click(self,loc:tuple[int,int],button:str='left',clicks:int=2):
+    def click(self,loc:tuple[int,int],button:str='left',clicks:int=1):
         x,y=loc
         pg.click(x,y,button=button,clicks=clicks,duration=0.1)
 


### PR DESCRIPTION
## Summary

- **Crash bug:** `switch_app` and `resize_app` both access `self.desktop_state` without checking if it has been populated. `desktop_state` is initialised to `None` in `Desktop.__init__` and only set after `get_state()` is called. Calling `App-Tool` with `mode=switch` or `mode=resize` before `State-Tool` raises `AttributeError: 'NoneType' object has no attribute 'active_app'`, which hangs the `stdio` MCP transport and causes all subsequent tool calls to time out indefinitely.
- **Default mismatch:** `Desktop.click()` in `service.py` defaulted to `clicks=2` (double-click) while the `Click-Tool` definition in `main.py` exposes `clicks=1`. Aligned both to single-click.

## Changes

- `resize_app`: call `self.get_state()` if `self.desktop_state is None` before accessing it
- `switch_app`: same guard
- `Desktop.click()`: change default `clicks=2` → `clicks=1`

## Test plan

- [ ] Call `App-Tool(mode=switch, name=...)` without a prior `State-Tool` call — should switch window cleanly instead of hanging
- [ ] Call `App-Tool(mode=resize)` without a prior `State-Tool` call — should return "No active app found" or resize cleanly
- [ ] `Click-Tool` with default `clicks` param produces a single click, not a double-click

🤖 Generated with [Claude Code](https://claude.com/claude-code)