### PR TITLE
fix(cli): guard auth banner against non-UTF-8 stdout

### DIFF
--- a/src/windows_mcp/__main__.py
+++ b/src/windows_mcp/__main__.py
@@ -34,6 +34,28 @@ import sys
 
 logger = logging.getLogger(__name__)
 
+
+def _echo_section(title: str) -> None:
+    """Print a section heading via click.echo, falling back to ASCII
+    when the current stdout encoding can't represent the U+2500
+    box-drawing character.
+
+    Without this guard, `windows-mcp auth` crashes on the default
+    PowerShell / cmd console (cp1252) with a UnicodeEncodeError when
+    click.echo hits ─. The config file is already written at this
+    point, but the noisy traceback obscures the success and breaks
+    scripted callers that treat exit-nonzero as a real failure.
+    Setting PYTHONIOENCODING=utf-8 is a workaround; this is the fix.
+    """
+    enc = getattr(sys.stdout, "encoding", None) or "ascii"
+    try:
+        "─".encode(enc)
+        bar = "─" * 3
+    except (UnicodeEncodeError, LookupError):
+        bar = "==="
+    click.echo(f"\n{bar} {title} {bar}")
+
+
 desktop: Any | None = None
 watchdog: Any | None = None
 analytics: Any | None = None
@@ -877,7 +899,7 @@ def auth(transport: str, host: str, port: int, with_tls: bool, force: bool) -> N
     click.echo(f"\nSaved to {config_path}")
 
     if transport == "stdio":
-        click.echo("\n─── Claude Desktop config (stdio) ───")
+        _echo_section("Claude Desktop config (stdio)")
         click.echo(
             """\
 {
@@ -895,11 +917,11 @@ def auth(transport: str, host: str, port: int, with_tls: bool, force: bool) -> N
     mcp_url = f"{scheme}://{host}:{port}/mcp/"
     sse_url = f"{scheme}://{host}:{port}/sse"
 
-    click.echo("\n─── Start the server ───")
+    _echo_section("Start the server")
     click.echo("  windows-mcp serve")
 
     if transport == "sse":
-        click.echo("\n─── Claude Desktop config (SSE) ───")
+        _echo_section("Claude Desktop config (SSE)")
         click.echo(
             f"""\
 {{
@@ -913,7 +935,7 @@ def auth(transport: str, host: str, port: int, with_tls: bool, force: bool) -> N
 }}"""
         )
     else:
-        click.echo("\n─── Claude Desktop config (Streamable HTTP) ───")
+        _echo_section("Claude Desktop config (Streamable HTTP)")
         click.echo(
             f"""\
 {{


### PR DESCRIPTION
## Problem

`windows-mcp auth` crashes on the default PowerShell / cmd console (cp1252) with `UnicodeEncodeError` when `click.echo` emits the U+2500 box-drawing characters in its section headings (`─── Start the server ───`, etc).

The config file is already written by the time the banner prints, so functionality is intact — but the traceback obscures success, makes the command look like it failed, and breaks scripted callers that treat exit-nonzero as a real failure. The current workaround is `set PYTHONIOENCODING=utf-8` before invoking, which is non-obvious.

Reproduction:

```
PS C:\> windows-mcp auth --transport streamable-http --host 0.0.0.0 --port 8765 --force
Generated auth key: ...
Saved to C:\Users\<user>\.windows-mcp\config.toml
  File "...\windows_mcp\__main__.py", line 898, in auth
    click.echo("\n─── Start the server ───")
  ...
  File "...\Lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode characters in position 2-4: character maps to <undefined>
```

## Fix

Route the four affected banner echoes through a small helper that probes `sys.stdout.encoding` and falls back to ASCII (`=== Start the server ===`) when the encoding can't represent U+2500. UTF-8 consoles see the same box-drawing output as before; cp1252 consoles see ASCII and no crash.

## Testing

Verified on Windows 11 PowerShell (cp1252) with Python 3.13 from a uv tool install — both `auth` paths (`--transport stdio` and `--transport streamable-http`) now print cleanly without setting any env vars. UTF-8 path (`PYTHONIOENCODING=utf-8`) is unchanged.

Context: this came up during a homelab deployment of windows-mcp 0.8.2 on a Win11 dev VM; details at homelab-ops/findings/2026-06-18-windows-mcp-deployed-vm-207.md if useful.