### PR TITLE
fix(snapshot): retry get_active_window on transient empty UIA results

### DIFF
--- a/src/windows_mcp/desktop/service.py
+++ b/src/windows_mcp/desktop/service.py
@@ -798,45 +798,78 @@ class Desktop:
             handles.add(secondary_taskbar_hwnd)
         return handles
 
+    # Tuned retry envelope for transient UIA empty results. The OS
+    # briefly returns NULL from GetForegroundWindow during focus
+    # transitions, app launches, and notification overlays — three
+    # attempts at 100 ms each covers the typical race without
+    # noticeably slowing the snapshot path when state is steady.
+    _UIA_RETRIES = 3
+    _UIA_RETRY_SLEEP_MS = 100
+
     def get_active_window(self, windows: list[Window] | None = None) -> Window | None:
-        try:
-            if windows is None:
-                windows, _ = self.get_windows()
-            active_window = self.get_foreground_window()
-            if active_window.ClassName == "Progman":
-                return None
-            active_window_handle = active_window.NativeWindowHandle
-            for window in windows:
-                if window.handle != active_window_handle:
+        """Return the foreground app window, retrying briefly on transient
+        empty results.
+
+        GetForegroundWindow can return NULL during focus transitions, app
+        launches, and notification-overlay flicker — even when there is a
+        visible focused window on screen. Without a retry, Snapshot
+        reports "No active window found" and the caller is left blind.
+        """
+        last_error = None
+        for attempt in range(self._UIA_RETRIES):
+            try:
+                if windows is None:
+                    windows, _ = self.get_windows()
+                active_window = self.get_foreground_window()
+                if active_window is None:
+                    # NULL foreground — retry, this often clears on the
+                    # next pass once whatever was transitioning settles.
+                    sleep(self._UIA_RETRY_SLEEP_MS / 1000.0)
                     continue
-                return window
-            # In case active window is not present in the windows list
-            return Window(
-                **{
-                    "name": active_window.Name,
-                    "is_browser": self.is_window_browser(active_window),
-                    "depth": 0,
-                    "bounding_box": BoundingBox(
-                        left=active_window.BoundingRectangle.left,
-                        top=active_window.BoundingRectangle.top,
-                        right=active_window.BoundingRectangle.right,
-                        bottom=active_window.BoundingRectangle.bottom,
-                        width=active_window.BoundingRectangle.width(),
-                        height=active_window.BoundingRectangle.height(),
-                    ),
-                    "status": self.get_window_status(active_window),
-                    "handle": active_window_handle,
-                    "process_id": active_window.ProcessId,
-                }
-            )
-        except Exception as ex:
-            logger.error(f"Error in get_active_window: {ex}")
+                if active_window.ClassName == "Progman":
+                    return None
+                active_window_handle = active_window.NativeWindowHandle
+                for window in windows:
+                    if window.handle != active_window_handle:
+                        continue
+                    return window
+                # In case active window is not present in the windows list
+                return Window(
+                    **{
+                        "name": active_window.Name,
+                        "is_browser": self.is_window_browser(active_window),
+                        "depth": 0,
+                        "bounding_box": BoundingBox(
+                            left=active_window.BoundingRectangle.left,
+                            top=active_window.BoundingRectangle.top,
+                            right=active_window.BoundingRectangle.right,
+                            bottom=active_window.BoundingRectangle.bottom,
+                            width=active_window.BoundingRectangle.width(),
+                            height=active_window.BoundingRectangle.height(),
+                        ),
+                        "status": self.get_window_status(active_window),
+                        "handle": active_window_handle,
+                        "process_id": active_window.ProcessId,
+                    }
+                )
+            except Exception as ex:
+                last_error = ex
+                # Same retry policy for transient exceptions —
+                # ControlFromHandle(NULL) raises during focus transitions
+                # and the next attempt usually succeeds.
+                sleep(self._UIA_RETRY_SLEEP_MS / 1000.0)
+                continue
+        if last_error is not None:
+            logger.error(f"Error in get_active_window after {self._UIA_RETRIES} retries: {last_error}")
         return None
 
-    def get_foreground_window(self) -> uia.Control:
+    def get_foreground_window(self) -> uia.Control | None:
         handle = uia.GetForegroundWindow()
-        active_window = self.get_window_from_element_handle(handle)
-        return active_window
+        # NULL handle means no window has foreground focus right now —
+        # don't pass that into ControlFromHandle, which would raise.
+        if not handle:
+            return None
+        return self.get_window_from_element_handle(handle)
 
     def get_window_from_element_handle(self, element_handle: int) -> uia.Control:
         current = uia.ControlFromHandle(element_handle)


### PR DESCRIPTION
## Problem

`Snapshot` reports `No active window found` even when there is clearly a visible focused window on screen. Reproduces reliably on a Win11 dev VM:

1. `App(mode="launch", name="notepad")` → returns `Notepad launched.`
2. `Wait(duration=3)`
3. `Snapshot(use_vision=False, use_ui_tree=False)` → returns:

   > `Focused Window: No active window found`
   > `Opened Windows: No windows found`

A `Screenshot` taken at the same moment shows Notepad foregrounded and rendered. Subsequent `Click(label=N)` / `Type(label=N)` / `App(mode="switch")` calls then fail because the AX tree they look up against is empty.

Also reproduces during steady state when a system toast notification briefly steals foreground focus — the snapshot taken in that ~200ms window comes back empty.

## Cause

`get_foreground_window` calls `uia.GetForegroundWindow()` which returns a NULL handle during focus transitions. Two downstream issues:

1. `get_foreground_window` passes the NULL handle into `ControlFromHandle` which raises — caught by the broad `except Exception` in `get_active_window`, surfacing as `None`.
2. Even when a non-NULL handle eventually arrives, `get_active_window` is called exactly once per Snapshot, so any transient empty result becomes a hard "no window" result for the caller.

## Fix

- Wrap `get_active_window`'s body in a small retry loop (3 attempts, 100 ms apart). Tuned conservatively — covers the typical transition window without slowing the steady-state path meaningfully.
- Make `get_foreground_window` NULL-safe: return `None` explicitly when the handle is 0 instead of letting `ControlFromHandle` raise. The retry loop handles `None` explicitly.
- Treat transient `ControlFromHandle` / `NativeWindowHandle` exceptions identically — they are the same race surfaced as an exception rather than as a NULL.

## Testing

On a Win11 dev VM with windows-mcp 0.8.2 + this patch, `Snapshot` immediately after `App.launch` returns the expected focused window in steady state; in cases where the first attempt would have hit a transition, the second attempt now succeeds without changing the caller-visible API. Logs at debug level show the retries when they fire.

Context: came up during a homelab deployment of windows-mcp 0.8.2 on a Win11 dev VM where Snapshot was unusable for label-driven workflows. After this patch (combined with hiding the launcher's console window so it doesn't itself foreground over the user app), Snapshot enumerates correctly.

PR is one of three from this deployment — companions:
- #292 `fix(cli): guard auth banner against non-UTF-8 stdout`
- #293 `fix(type): paste long text via clipboard to avoid SendKeys scan-code race`