### PR TITLE
Add guarded input target assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,6 +708,11 @@ MCP Client can access the following tools to interact with Windows:
 - `Notification`: Send a Windows toast notification with a title and message.
 - `Registry`: Read, write, delete, or list Windows Registry values and keys.
 
+Input tools that send foreground input (`Click`, `Type`, `Scroll`, `Move`, and `Shortcut`) also
+accept optional `expected_window_title` and `expected_process` guards. When supplied, Windows-MCP
+checks the current foreground root window before sending input and fails before the action if the
+title substring or exact process basename does not match.
+
 
 ## 🤝 Connect with Us
 Stay updated and join our community:

--- a/src/windows_mcp/desktop/service.py
+++ b/src/windows_mcp/desktop/service.py
@@ -770,6 +770,49 @@ class Desktop:
                 return 'Invalid type. Use "horizontal" or "vertical".'
         return None
 
+    def assert_foreground_target(
+        self,
+        expected_window_title: str | None = None,
+        expected_process: str | None = None,
+    ) -> dict[str, object] | None:
+        if expected_window_title is None and expected_process is None:
+            return None
+
+        active_window = self.get_foreground_window()
+        if active_window is None:
+            raise ValueError("No foreground window is available for target validation")
+
+        title = active_window.Name or ""
+        process_name = ""
+        if expected_process is not None:
+            try:
+                process_name = Process(active_window.ProcessId).name()
+            except Exception as exc:
+                raise ValueError("Failed to resolve foreground process name") from exc
+
+        if (
+            expected_window_title is not None
+            and expected_window_title.casefold() not in title.casefold()
+        ):
+            raise ValueError(
+                "Foreground window title did not match expected_window_title: "
+                f"expected substring {expected_window_title!r}, actual {title!r}"
+            )
+
+        if expected_process is not None:
+            expected_basename = os.path.basename(expected_process).casefold()
+            if process_name.casefold() != expected_basename:
+                raise ValueError(
+                    "Foreground process did not match expected_process: "
+                    f"expected {expected_basename!r}, actual {process_name!r}"
+                )
+
+        return {
+            "title": title,
+            "process": process_name or None,
+            "process_id": active_window.ProcessId,
+        }
+
     def drag(self, loc: tuple[int, int] | list[int]):
         if isinstance(loc, list):
             x, y = loc[0], loc[1]
@@ -931,7 +974,9 @@ class Desktop:
                 sleep(self._UIA_RETRY_SLEEP_MS / 1000.0)
                 continue
         if last_error is not None:
-            logger.error(f"Error in get_active_window after {self._UIA_RETRIES} retries: {last_error}")
+            logger.error(
+                f"Error in get_active_window after {self._UIA_RETRIES} retries: {last_error}"
+            )
         return None
 
     def get_foreground_window(self) -> uia.Control | None:

--- a/src/windows_mcp/tools/input.py
+++ b/src/windows_mcp/tools/input.py
@@ -178,6 +178,18 @@ def _validate_wait_for_args(
     return normalized
 
 
+def _assert_input_target(
+    desktop: Any,
+    expected_window_title: str | None,
+    expected_process: str | None,
+) -> None:
+    if expected_window_title is not None or expected_process is not None:
+        desktop.assert_foreground_target(
+            expected_window_title=expected_window_title,
+            expected_process=expected_process,
+        )
+
+
 def register(
     mcp: Any,
     *,
@@ -206,6 +218,8 @@ def register(
         label: int | None = None,
         button: Literal["left", "right", "middle"] = "left",
         clicks: int = 1,
+        expected_window_title: str | None = None,
+        expected_process: str | None = None,
         ctx: Context = None,
     ) -> str:
         desktop = get_desktop()
@@ -217,6 +231,7 @@ def register(
         if len(loc) != 2:
             raise ValueError("Location must be a list of exactly 2 integers [x, y]")
         x, y = loc[0], loc[1]
+        _assert_input_target(desktop, expected_window_title, expected_process)
         desktop.click(loc=loc, button=button, clicks=clicks)
         num_clicks = {0: "Hover", 1: "Single", 2: "Double"}
         return f"{num_clicks.get(clicks)} {button} clicked at ({x},{y})."
@@ -240,6 +255,8 @@ def register(
         clear: bool | str = False,
         caret_position: Literal["start", "idle", "end"] = "idle",
         press_enter: bool | str = False,
+        expected_window_title: str | None = None,
+        expected_process: str | None = None,
         ctx: Context = None,
     ) -> str:
         desktop = get_desktop()
@@ -251,6 +268,7 @@ def register(
         if len(loc) != 2:
             raise ValueError("Location must be a list of exactly 2 integers [x, y]")
         x, y = loc[0], loc[1]
+        _assert_input_target(desktop, expected_window_title, expected_process)
         desktop.type(
             loc=loc,
             text=text,
@@ -278,6 +296,8 @@ def register(
         type: Literal["horizontal", "vertical"] = "vertical",
         direction: Literal["up", "down", "left", "right"] = "down",
         wheel_times: int = 1,
+        expected_window_title: str | None = None,
+        expected_process: str | None = None,
         ctx: Context = None,
     ) -> str:
         desktop = get_desktop()
@@ -286,6 +306,7 @@ def register(
             loc = _resolve_label(desktop, label)
         if loc and len(loc) != 2:
             raise ValueError("Location must be a list of exactly 2 integers [x, y]")
+        _assert_input_target(desktop, expected_window_title, expected_process)
         response = desktop.scroll(loc, type, direction, wheel_times)
         if response:
             return response
@@ -317,6 +338,8 @@ def register(
         loc: list[int] | str | None = None,
         label: int | None = None,
         drag: bool | str = False,
+        expected_window_title: str | None = None,
+        expected_process: str | None = None,
         ctx: Context = None,
     ) -> str:
         desktop = get_desktop()
@@ -329,6 +352,7 @@ def register(
         if len(loc) != 2:
             raise ValueError("loc must be a list of exactly 2 integers [x, y]")
         x, y = loc[0], loc[1]
+        _assert_input_target(desktop, expected_window_title, expected_process)
         if drag:
             desktop.drag(loc)
             return f"Dragged to ({x},{y})."
@@ -348,8 +372,15 @@ def register(
         ),
     )
     @with_analytics(get_analytics(), "Shortcut-Tool")
-    def shortcut_tool(shortcut: str, ctx: Context = None):
-        get_desktop().shortcut(shortcut)
+    def shortcut_tool(
+        shortcut: str,
+        expected_window_title: str | None = None,
+        expected_process: str | None = None,
+        ctx: Context = None,
+    ):
+        desktop = get_desktop()
+        _assert_input_target(desktop, expected_window_title, expected_process)
+        desktop.shortcut(shortcut)
         return f"Pressed {shortcut}."
 
     @mcp.tool(

--- a/tests/test_foreground_target_assertions.py
+++ b/tests/test_foreground_target_assertions.py
@@ -1,0 +1,84 @@
+from types import SimpleNamespace
+
+import pytest
+
+from windows_mcp.desktop import service
+from windows_mcp.desktop.service import Desktop
+
+
+def _desktop() -> Desktop:
+    desktop = Desktop.__new__(Desktop)
+    desktop.desktop_state = None
+    return desktop
+
+
+def test_assert_foreground_target_returns_none_without_guards() -> None:
+    desktop = _desktop()
+
+    assert desktop.assert_foreground_target() is None
+
+
+def test_assert_foreground_target_accepts_matching_title_and_process(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    desktop = _desktop()
+
+    monkeypatch.setattr(
+        desktop,
+        "get_foreground_window",
+        lambda: SimpleNamespace(Name="Untitled - Notepad", ProcessId=123),
+    )
+    monkeypatch.setattr(service, "Process", lambda pid: SimpleNamespace(name=lambda: "notepad.exe"))
+
+    result = desktop.assert_foreground_target(
+        expected_window_title="notepad",
+        expected_process="NOTEPAD.EXE",
+    )
+
+    assert result == {
+        "title": "Untitled - Notepad",
+        "process": "notepad.exe",
+        "process_id": 123,
+    }
+
+
+def test_assert_foreground_target_rejects_title_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    desktop = _desktop()
+
+    monkeypatch.setattr(
+        desktop,
+        "get_foreground_window",
+        lambda: SimpleNamespace(Name="Calculator", ProcessId=123),
+    )
+
+    with pytest.raises(ValueError, match="expected_window_title"):
+        desktop.assert_foreground_target(expected_window_title="Notepad")
+
+
+def test_assert_foreground_target_rejects_process_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    desktop = _desktop()
+
+    monkeypatch.setattr(
+        desktop,
+        "get_foreground_window",
+        lambda: SimpleNamespace(Name="Untitled - Notepad", ProcessId=123),
+    )
+    monkeypatch.setattr(service, "Process", lambda pid: SimpleNamespace(name=lambda: "notepad.exe"))
+
+    with pytest.raises(ValueError, match="expected_process"):
+        desktop.assert_foreground_target(expected_process="note.exe")
+
+
+def test_assert_foreground_target_rejects_missing_foreground(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    desktop = _desktop()
+
+    monkeypatch.setattr(desktop, "get_foreground_window", lambda: None)
+
+    with pytest.raises(ValueError, match="No foreground window"):
+        desktop.assert_foreground_target(expected_process="notepad.exe")

--- a/tests/test_guarded_input_tools.py
+++ b/tests/test_guarded_input_tools.py
@@ -1,0 +1,137 @@
+import asyncio
+from collections.abc import Callable
+
+import pytest
+
+from windows_mcp.tools.input import register
+
+
+class FakeMCP:
+    def __init__(self) -> None:
+        self.tools: dict[str, Callable] = {}
+
+    def tool(self, *, name: str, **kwargs: object) -> Callable:
+        def decorator(func: Callable) -> Callable:
+            self.tools[name] = func
+            return func
+
+        return decorator
+
+
+class FakeDesktop:
+    def __init__(self, *, fail_guard: bool = False) -> None:
+        self.desktop_state = object()
+        self.fail_guard = fail_guard
+        self.guard_calls: list[dict[str, str | None]] = []
+        self.action_calls: list[tuple[str, object]] = []
+
+    def assert_foreground_target(
+        self,
+        expected_window_title: str | None = None,
+        expected_process: str | None = None,
+    ) -> None:
+        self.guard_calls.append(
+            {
+                "expected_window_title": expected_window_title,
+                "expected_process": expected_process,
+            }
+        )
+        if self.fail_guard:
+            raise ValueError("foreground target mismatch")
+
+    def click(self, **kwargs: object) -> None:
+        self.action_calls.append(("click", kwargs))
+
+    def type(self, **kwargs: object) -> None:
+        self.action_calls.append(("type", kwargs))
+
+    def scroll(self, *args: object) -> None:
+        self.action_calls.append(("scroll", args))
+
+    def move(self, loc: list[int]) -> None:
+        self.action_calls.append(("move", loc))
+
+    def drag(self, loc: list[int]) -> None:
+        self.action_calls.append(("drag", loc))
+
+    def shortcut(self, shortcut: str) -> None:
+        self.action_calls.append(("shortcut", shortcut))
+
+
+def _tools(desktop: FakeDesktop) -> dict[str, Callable]:
+    mcp = FakeMCP()
+    register(mcp, get_desktop=lambda: desktop, get_analytics=lambda: None)
+    return mcp.tools
+
+
+def test_legacy_click_does_not_assert_target() -> None:
+    desktop = FakeDesktop()
+
+    result = asyncio.run(_tools(desktop)["Click"](loc=[10, 20]))
+
+    assert result == "Single left clicked at (10,20)."
+    assert desktop.guard_calls == []
+    assert desktop.action_calls[0][0] == "click"
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "kwargs", "expected_action"),
+    [
+        ("Click", {"loc": [10, 20]}, "click"),
+        ("Type", {"text": "hello", "loc": [10, 20]}, "type"),
+        ("Scroll", {"loc": [10, 20]}, "scroll"),
+        ("Move", {"loc": [10, 20]}, "move"),
+        ("Shortcut", {"shortcut": "ctrl+s"}, "shortcut"),
+    ],
+)
+def test_guarded_input_tools_assert_target_before_input(
+    tool_name: str,
+    kwargs: dict[str, object],
+    expected_action: str,
+) -> None:
+    desktop = FakeDesktop()
+    kwargs.update(
+        {
+            "expected_window_title": "Notepad",
+            "expected_process": "notepad.exe",
+        }
+    )
+
+    asyncio.run(_tools(desktop)[tool_name](**kwargs))
+
+    assert desktop.guard_calls == [
+        {
+            "expected_window_title": "Notepad",
+            "expected_process": "notepad.exe",
+        }
+    ]
+    assert desktop.action_calls[0][0] == expected_action
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "kwargs"),
+    [
+        ("Click", {"loc": [10, 20]}),
+        ("Type", {"text": "hello", "loc": [10, 20]}),
+        ("Scroll", {"loc": [10, 20]}),
+        ("Move", {"loc": [10, 20]}),
+        ("Shortcut", {"shortcut": "ctrl+s"}),
+    ],
+)
+def test_guarded_input_tools_fail_before_input_on_mismatch(
+    tool_name: str,
+    kwargs: dict[str, object],
+) -> None:
+    desktop = FakeDesktop(fail_guard=True)
+    kwargs["expected_process"] = "notepad.exe"
+
+    with pytest.raises(ValueError, match="foreground target mismatch"):
+        asyncio.run(_tools(desktop)[tool_name](**kwargs))
+
+    assert desktop.guard_calls == [
+        {
+            "expected_window_title": None,
+            "expected_process": "notepad.exe",
+        }
+    ]
+    assert desktop.action_calls == []


### PR DESCRIPTION
## Summary

Adds optional shared foreground target assertions to input tools that send foreground input:

- `Click`
- `Type`
- `Scroll`
- `Move`
- `Shortcut`

The new optional parameters are `expected_window_title` and `expected_process`. When supplied, Windows-MCP validates the current foreground root window before sending input and fails before the action if the target does not match.

## Motivation

Agents often observe a target window and then send input in a later tool call. Today the input call trusts whichever window is foreground at execution time. These guards give callers an opt-in fail-closed check for wrong-target input.

Issue: #314

## Public API and compatibility

Existing unguarded calls remain unchanged. Guarded calls can opt in like this:

```python
Click(loc=[x, y], expected_window_title="Notepad", expected_process="notepad.exe")
Type(text="hello", loc=[x, y], expected_window_title="Notepad")
Scroll(loc=[x, y], expected_process="notepad.exe")
Move(loc=[x, y], expected_window_title="Notepad")
Shortcut(shortcut="ctrl+s", expected_process="notepad.exe")
```

Matching semantics:

- `expected_window_title`: case-insensitive substring match against the foreground root title;
- `expected_process`: case-insensitive exact executable basename match;
- if both are supplied, both must match;
- mismatch fails before low-level input.

## Implementation overview

- `Desktop.assert_foreground_target(...)` centralizes foreground title/process validation.
- Input tools call the shared assertion before their low-level action.
- README documents the optional guard parameters.
- Tests cover legacy behavior, guard success, guard failure-before-input, both-guard forwarding, missing foreground, and title/process mismatch.

## Testing

Focused checks passed:

```text
uv run pytest tests/test_guarded_input_tools.py tests/test_foreground_target_assertions.py
uv run ruff check src/windows_mcp/desktop/service.py src/windows_mcp/tools/input.py tests/test_guarded_input_tools.py tests/test_foreground_target_assertions.py
```

Focused pytest result:

```text
16 passed
```

Full repository gates were also run. They still show pre-existing baseline failures unrelated to this PR:

```text
uv run pytest
# 334 passed, 3 failed in tests/test_iserror_compliance.py due missing shell/clipboard/registry exported tool functions

uv run ruff check .
# 64 pre-existing lint errors
```

## Notes

This PR is intentionally separate from deterministic drag PR #313. It does not include local planning documents, private consumer details, or unrelated cleanup.