### PR TITLE
Add exact window control tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,6 +695,7 @@ MCP Client can access the following tools to interact with Windows:
 - `Shortcut`: Press keyboard shortcuts (`Ctrl+c`, `Alt+Tab`, etc).
 - `Wait`: Pause for a defined duration.
 - `WaitFor`: Wait until text, an active window, an element, or a focused element appears by polling UI state inside one tool call.
+- `Window`: Find, activate, and set outer/client bounds for exact windows without fuzzy matching.
 - `Screenshot`: Fast screenshot-first desktop capture with cursor position, active/open windows, and an image. Skips UI tree extraction for speed and should be the default first call when you mainly need visual context. Supports `display=[0]` or `display=[0,1]` using zero-based active Windows display indices. After capture, a brief orange-red glowing border is drawn inside the captured area as a visual confirmation (set `WINDOWS_MCP_DISABLE_FLASH=1` to disable).
 - `Snapshot`: Full desktop state capture for workflows that need interactive element ids, scrollable regions, or `use_dom=True` browser extraction. Supports `use_vision=True` for including screenshots and `display=[0]` or `display=[0,1]` using zero-based active Windows display indices.
 - `App`: To launch an application from the start menu, resize or move the window and switch between apps.

--- a/src/windows_mcp/desktop/service.py
+++ b/src/windows_mcp/desktop/service.py
@@ -616,6 +616,154 @@ class Desktop:
         except Exception as e:
             logger.exception(f"Failed to bring window to top: {e}")
 
+    def _window_process_name(self, process_id: int) -> str | None:
+        try:
+            return Process(process_id).name()
+        except Exception:
+            return None
+
+    def _client_bounds(self, handle: int) -> dict[str, int]:
+        left, top, right, bottom = win32gui.GetClientRect(handle)
+        screen_left, screen_top = win32gui.ClientToScreen(handle, (left, top))
+        width = right - left
+        height = bottom - top
+        return {
+            "left": screen_left,
+            "top": screen_top,
+            "width": width,
+            "height": height,
+            "right": screen_left + width,
+            "bottom": screen_top + height,
+        }
+
+    def _outer_bounds(self, handle: int) -> dict[str, int]:
+        left, top, right, bottom = win32gui.GetWindowRect(handle)
+        return {
+            "left": left,
+            "top": top,
+            "width": right - left,
+            "height": bottom - top,
+            "right": right,
+            "bottom": bottom,
+        }
+
+    def _window_identity(self, window: Window) -> dict[str, object]:
+        handle = window.handle
+        return {
+            "handle": handle,
+            "process_id": window.process_id,
+            "process": self._window_process_name(window.process_id),
+            "title": window.name,
+            "status": window.status.value,
+            "outer": self._outer_bounds(handle),
+            "client": self._client_bounds(handle),
+        }
+
+    def find_exact_windows(
+        self,
+        title: str | None = None,
+        title_match: Literal["exact", "contains"] = "contains",
+        process: str | None = None,
+        process_id: int | None = None,
+        handle: int | None = None,
+    ) -> list[dict[str, object]]:
+        if title_match not in {"exact", "contains"}:
+            raise ValueError('title_match must be "exact" or "contains"')
+
+        windows, _ = self.get_windows()
+        matches = []
+        expected_process = os.path.basename(process).casefold() if process else None
+        for window in windows:
+            if handle is not None and window.handle != handle:
+                continue
+            if process_id is not None and window.process_id != process_id:
+                continue
+            if title is not None:
+                actual_title = window.name.casefold()
+                expected_title = title.casefold()
+                if title_match == "exact" and actual_title != expected_title:
+                    continue
+                if title_match == "contains" and expected_title not in actual_title:
+                    continue
+            if expected_process is not None:
+                process_name = self._window_process_name(window.process_id)
+                if process_name is None or process_name.casefold() != expected_process:
+                    continue
+            if not win32gui.IsWindow(window.handle):
+                continue
+            matches.append(self._window_identity(window))
+        return matches
+
+    def _require_exact_window(
+        self,
+        handle: int,
+        process_id: int | None = None,
+        process: str | None = None,
+        title: str | None = None,
+        title_match: Literal["exact", "contains"] = "contains",
+    ) -> dict[str, object]:
+        if not win32gui.IsWindow(handle):
+            raise ValueError("Invalid or stale window handle")
+        matches = self.find_exact_windows(
+            title=title,
+            title_match=title_match,
+            process=process,
+            process_id=process_id,
+            handle=handle,
+        )
+        if not matches:
+            raise ValueError("No window matched the supplied identity")
+        if len(matches) > 1:
+            raise ValueError("Window identity was ambiguous")
+        return matches[0]
+
+    def activate_exact_window(
+        self,
+        handle: int,
+        process_id: int | None = None,
+        process: str | None = None,
+        title: str | None = None,
+        title_match: Literal["exact", "contains"] = "contains",
+    ) -> dict[str, object]:
+        window = self._require_exact_window(handle, process_id, process, title, title_match)
+        self.bring_window_to_top(handle)
+        foreground_handle = win32gui.GetForegroundWindow()
+        if foreground_handle != handle:
+            raise ValueError(
+                f"Failed to activate exact window: foreground handle is {foreground_handle}"
+            )
+        return window
+
+    def set_exact_window_bounds(
+        self,
+        handle: int,
+        outer: list[int] | None = None,
+        client: list[int] | None = None,
+        process_id: int | None = None,
+        process: str | None = None,
+        title: str | None = None,
+        title_match: Literal["exact", "contains"] = "contains",
+    ) -> dict[str, object]:
+        if outer is not None and client is not None:
+            raise ValueError("Provide only one of outer or client bounds")
+        window = self._require_exact_window(handle, process_id, process, title, title_match)
+        if outer is None and client is None:
+            return window
+
+        if outer is not None:
+            x, y, width, height = outer
+        else:
+            current_outer = self._outer_bounds(handle)
+            current_client = self._client_bounds(handle)
+            client_x, client_y, client_width, client_height = client
+            x = client_x - (current_client["left"] - current_outer["left"])
+            y = client_y - (current_client["top"] - current_outer["top"])
+            width = client_width + (current_outer["width"] - current_client["width"])
+            height = client_height + (current_outer["height"] - current_client["height"])
+
+        win32gui.MoveWindow(handle, int(x), int(y), int(width), int(height), True)
+        return self._require_exact_window(handle, process_id, process, title, title_match)
+
     def get_coordinates_from_label(self, label: int) -> tuple[int, int]:
         tree_state = self.desktop_state.tree_state
         if label < len(tree_state.interactive_nodes):
@@ -931,7 +1079,9 @@ class Desktop:
                 sleep(self._UIA_RETRY_SLEEP_MS / 1000.0)
                 continue
         if last_error is not None:
-            logger.error(f"Error in get_active_window after {self._UIA_RETRIES} retries: {last_error}")
+            logger.error(
+                f"Error in get_active_window after {self._UIA_RETRIES} retries: {last_error}"
+            )
         return None
 
     def get_foreground_window(self) -> uia.Control | None:

--- a/src/windows_mcp/tools/__init__.py
+++ b/src/windows_mcp/tools/__init__.py
@@ -12,6 +12,7 @@ from windows_mcp.tools import (
     scrape,
     shell,
     snapshot,
+    window,
 )
 
 _MODULES = [
@@ -26,6 +27,7 @@ _MODULES = [
     process,
     notification,
     registry,
+    window,
 ]
 
 

--- a/src/windows_mcp/tools/window.py
+++ b/src/windows_mcp/tools/window.py
@@ -1,0 +1,88 @@
+"""Window tool - exact window discovery, activation, and bounds."""
+
+import json
+from typing import Literal
+
+from fastmcp import Context
+from mcp.types import ToolAnnotations
+from windows_mcp.infrastructure import with_analytics
+
+
+def _as_bounds(value: list[int] | str | None) -> list[int] | None:
+    if value is None or isinstance(value, list):
+        bounds = value
+    else:
+        bounds = json.loads(value)
+    if bounds is not None and len(bounds) != 4:
+        raise ValueError("Bounds must be a list of exactly 4 integers [x, y, width, height]")
+    return bounds
+
+
+def register(mcp, *, get_desktop, get_analytics):
+    @mcp.tool(
+        name="Window",
+        description=(
+            "Find, activate, or set bounds for exact windows without fuzzy matching. "
+            "Modes: find, activate, bounds. Use title/title_match, process, process_id, "
+            "and handle to narrow identity. Bounds are [x, y, width, height]."
+        ),
+        annotations=ToolAnnotations(
+            title="Window",
+            readOnlyHint=False,
+            destructiveHint=False,
+            idempotentHint=False,
+            openWorldHint=False,
+        ),
+    )
+    @with_analytics(get_analytics(), "Window-Tool")
+    def window_tool(
+        mode: Literal["find", "activate", "bounds"] = "find",
+        title: str | None = None,
+        title_match: Literal["exact", "contains"] = "contains",
+        process: str | None = None,
+        process_id: int | None = None,
+        handle: int | None = None,
+        outer: list[int] | str | None = None,
+        client: list[int] | str | None = None,
+        ctx: Context = None,
+    ) -> str:
+        desktop = get_desktop()
+        outer = _as_bounds(outer)
+        client = _as_bounds(client)
+
+        match mode:
+            case "find":
+                windows = desktop.find_exact_windows(
+                    title=title,
+                    title_match=title_match,
+                    process=process,
+                    process_id=process_id,
+                    handle=handle,
+                )
+                return json.dumps({"windows": windows, "count": len(windows)}, indent=2)
+            case "activate":
+                if handle is None:
+                    raise ValueError("handle is required when mode is activate")
+                window = desktop.activate_exact_window(
+                    handle=handle,
+                    process_id=process_id,
+                    process=process,
+                    title=title,
+                    title_match=title_match,
+                )
+                return json.dumps({"activated": window}, indent=2)
+            case "bounds":
+                if handle is None:
+                    raise ValueError("handle is required when mode is bounds")
+                window = desktop.set_exact_window_bounds(
+                    handle=handle,
+                    outer=outer,
+                    client=client,
+                    process_id=process_id,
+                    process=process,
+                    title=title,
+                    title_match=title_match,
+                )
+                return json.dumps({"window": window}, indent=2)
+
+        raise ValueError('mode must be one of "find", "activate", or "bounds"')

--- a/tests/test_exact_window_control.py
+++ b/tests/test_exact_window_control.py
@@ -1,0 +1,155 @@
+import asyncio
+import json
+from collections.abc import Callable
+
+import pytest
+
+from windows_mcp.desktop import service
+from windows_mcp.desktop.service import Desktop
+from windows_mcp.desktop.views import Status, Window
+from windows_mcp.tools import window as window_tool_module
+from windows_mcp.tree.views import BoundingBox
+
+
+class FakeMCP:
+    def __init__(self) -> None:
+        self.tools: dict[str, Callable] = {}
+
+    def tool(self, *, name: str, **kwargs: object) -> Callable:
+        def decorator(func: Callable) -> Callable:
+            self.tools[name] = func
+            return func
+
+        return decorator
+
+
+def _desktop() -> Desktop:
+    desktop = Desktop.__new__(Desktop)
+    desktop.desktop_state = None
+    return desktop
+
+
+def _window(title: str, handle: int = 100, process_id: int = 200) -> Window:
+    return Window(
+        name=title,
+        is_browser=False,
+        depth=0,
+        status=Status.NORMAL,
+        bounding_box=BoundingBox(left=0, top=0, right=100, bottom=100, width=100, height=100),
+        handle=handle,
+        process_id=process_id,
+    )
+
+
+def _patch_window_api(monkeypatch: pytest.MonkeyPatch, *, foreground: int = 100) -> list[tuple]:
+    moves: list[tuple] = []
+    monkeypatch.setattr(service.win32gui, "IsWindow", lambda handle: handle == 100)
+    monkeypatch.setattr(service.win32gui, "GetWindowRect", lambda handle: (10, 20, 210, 170))
+    monkeypatch.setattr(service.win32gui, "GetClientRect", lambda handle: (0, 0, 180, 120))
+    monkeypatch.setattr(service.win32gui, "ClientToScreen", lambda handle, point: (20, 50))
+    monkeypatch.setattr(service.win32gui, "GetForegroundWindow", lambda: foreground)
+    monkeypatch.setattr(
+        service.win32gui,
+        "MoveWindow",
+        lambda *args: moves.append(args),
+    )
+    monkeypatch.setattr(
+        service, "Process", lambda pid: type("P", (), {"name": lambda self: "app.exe"})()
+    )
+    return moves
+
+
+def test_find_exact_windows_filters_by_process_and_title(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    desktop = _desktop()
+    _patch_window_api(monkeypatch)
+    monkeypatch.setattr(desktop, "get_windows", lambda: ([_window("Target App")], {100}))
+
+    result = desktop.find_exact_windows(title="target", process="APP.EXE")
+
+    assert result == [
+        {
+            "handle": 100,
+            "process_id": 200,
+            "process": "app.exe",
+            "title": "Target App",
+            "status": "Normal",
+            "outer": {
+                "left": 10,
+                "top": 20,
+                "width": 200,
+                "height": 150,
+                "right": 210,
+                "bottom": 170,
+            },
+            "client": {
+                "left": 20,
+                "top": 50,
+                "width": 180,
+                "height": 120,
+                "right": 200,
+                "bottom": 170,
+            },
+        }
+    ]
+
+
+def test_activate_exact_window_verifies_foreground(monkeypatch: pytest.MonkeyPatch) -> None:
+    desktop = _desktop()
+    _patch_window_api(monkeypatch, foreground=100)
+    monkeypatch.setattr(desktop, "get_windows", lambda: ([_window("Target App")], {100}))
+    called: list[int] = []
+    monkeypatch.setattr(desktop, "bring_window_to_top", lambda handle: called.append(handle))
+
+    result = desktop.activate_exact_window(handle=100, process_id=200)
+
+    assert result["handle"] == 100
+    assert called == [100]
+
+
+def test_activate_exact_window_fails_when_readback_differs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    desktop = _desktop()
+    _patch_window_api(monkeypatch, foreground=999)
+    monkeypatch.setattr(desktop, "get_windows", lambda: ([_window("Target App")], {100}))
+    monkeypatch.setattr(desktop, "bring_window_to_top", lambda handle: None)
+
+    with pytest.raises(ValueError, match="Failed to activate"):
+        desktop.activate_exact_window(handle=100, process_id=200)
+
+
+def test_set_exact_client_bounds_converts_to_outer_bounds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    desktop = _desktop()
+    moves = _patch_window_api(monkeypatch)
+    monkeypatch.setattr(desktop, "get_windows", lambda: ([_window("Target App")], {100}))
+
+    desktop.set_exact_window_bounds(handle=100, process_id=200, client=[30, 70, 300, 200])
+
+    assert moves == [(100, 20, 40, 320, 230, True)]
+
+
+def test_window_tool_find_returns_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    desktop = _desktop()
+    monkeypatch.setattr(
+        desktop,
+        "find_exact_windows",
+        lambda **kwargs: [{"handle": 100, "title": "Target App"}],
+    )
+    mcp = FakeMCP()
+    window_tool_module.register(mcp, get_desktop=lambda: desktop, get_analytics=lambda: None)
+
+    result = json.loads(asyncio.run(mcp.tools["Window"](mode="find", title="Target")))
+
+    assert result == {"windows": [{"handle": 100, "title": "Target App"}], "count": 1}
+
+
+def test_window_tool_bounds_requires_handle() -> None:
+    mcp = FakeMCP()
+    window_tool_module.register(mcp, get_desktop=_desktop, get_analytics=lambda: None)
+
+    with pytest.raises(ValueError, match="handle is required"):
+        asyncio.run(mcp.tools["Window"](mode="bounds", outer=[0, 0, 100, 100]))


### PR DESCRIPTION
## Summary

Adds a new exact `Window` tool for deterministic window workflows without fuzzy matching:

- `mode="find"` returns matching windows with handle, PID, process, title, status, outer bounds, and client bounds;
- `mode="activate"` brings an exact handle to foreground and verifies foreground readback;
- `mode="bounds"` reports or sets exact outer/client bounds and returns actual geometry.

## Motivation

The existing `App` tool is convenience-oriented and supports fuzzy name matching. This PR keeps that behavior unchanged and adds a separate exact path for workflows that must avoid selecting similarly titled windows.

Issue: #316

## Public API

```python
Window(mode="find", title="Untitled - Notepad", title_match="contains", process="notepad.exe")
Window(mode="activate", handle=123456, process_id=7890, process="notepad.exe")
Window(mode="bounds", handle=123456, process_id=7890, outer=[x, y, width, height])
Window(mode="bounds", handle=123456, process_id=7890, client=[x, y, width, height])
```

Matching is exact for handles/PIDs/process basenames and exact-or-contains for titles. Client bounds are converted to outer bounds using current frame/client deltas, then actual geometry is returned after Windows applies constraints.

## Testing

Focused checks passed:

```text
uv run pytest tests/test_exact_window_control.py
uv run ruff check src/windows_mcp/desktop/service.py src/windows_mcp/tools/window.py src/windows_mcp/tools/__init__.py tests/test_exact_window_control.py
```

Focused pytest result:

```text
6 passed
```

Full repository pytest was also run and still shows the pre-existing baseline failures unrelated to this PR:

```text
uv run pytest
# 324 passed, 3 failed in tests/test_iserror_compliance.py due missing shell/clipboard/registry exported tool functions
```

## Notes

This PR is independent from deterministic drag PR #313 and guarded input PR #315. It does not include local planning documents or private consumer details.