### PR TITLE
Add display DPI inventory tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,6 +695,7 @@ MCP Client can access the following tools to interact with Windows:
 - `Shortcut`: Press keyboard shortcuts (`Ctrl+c`, `Alt+Tab`, etc).
 - `Wait`: Pause for a defined duration.
 - `WaitFor`: Wait until text, an active window, an element, or a focused element appears by polling UI state inside one tool call.
+- `DisplayInventory`: Read display layout, work areas, effective DPI, and scale metadata.
 - `Screenshot`: Fast screenshot-first desktop capture with cursor position, active/open windows, and an image. Skips UI tree extraction for speed and should be the default first call when you mainly need visual context. Supports `display=[0]` or `display=[0,1]` using zero-based active Windows display indices. After capture, a brief orange-red glowing border is drawn inside the captured area as a visual confirmation (set `WINDOWS_MCP_DISABLE_FLASH=1` to disable).
 - `Snapshot`: Full desktop state capture for workflows that need interactive element ids, scrollable regions, or `use_dom=True` browser extraction. Supports `use_vision=True` for including screenshots and `display=[0]` or `display=[0,1]` using zero-based active Windows display indices.
 - `App`: To launch an application from the start menu, resize or move the window and switch between apps.

--- a/src/windows_mcp/tools/__init__.py
+++ b/src/windows_mcp/tools/__init__.py
@@ -3,6 +3,7 @@
 from windows_mcp.tools import (
     app,
     clipboard,
+    display,
     filesystem,
     input,
     multi,
@@ -16,6 +17,7 @@ from windows_mcp.tools import (
 
 _MODULES = [
     app,
+    display,
     shell,
     filesystem,
     snapshot,

--- a/src/windows_mcp/tools/display.py
+++ b/src/windows_mcp/tools/display.py
@@ -1,0 +1,56 @@
+"""DisplayInventory tool - read-only display and DPI metadata."""
+
+import json
+
+from fastmcp import Context
+from mcp.types import ToolAnnotations
+from windows_mcp.infrastructure import with_analytics
+
+
+def _rect_to_dict(rect) -> dict[str, int] | None:
+    if rect is None:
+        return None
+    return {
+        "left": rect.left,
+        "top": rect.top,
+        "right": rect.right,
+        "bottom": rect.bottom,
+        "width": rect.width(),
+        "height": rect.height(),
+    }
+
+
+def register(mcp, *, get_desktop, get_analytics):
+    @mcp.tool(
+        name="DisplayInventory",
+        description=(
+            "Read active display layout and DPI metadata. Reports display index, device name, "
+            "monitor/work-area rectangles, primary flag, effective DPI, and scale."
+        ),
+        annotations=ToolAnnotations(
+            title="DisplayInventory",
+            readOnlyHint=True,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=False,
+        ),
+    )
+    @with_analytics(get_analytics(), "DisplayInventory-Tool")
+    def display_inventory_tool(ctx: Context = None) -> str:
+        displays = get_desktop().get_displays()
+        payload = {
+            "displays": [
+                {
+                    "index": display.index,
+                    "device_name": display.device_name,
+                    "primary": display.primary,
+                    "rect": _rect_to_dict(display.rect),
+                    "work_rect": _rect_to_dict(getattr(display, "work_rect", None)),
+                    "effective_dpi": getattr(display, "effective_dpi", None),
+                    "scale": getattr(display, "scale", None),
+                }
+                for display in displays
+            ],
+            "count": len(displays),
+        }
+        return json.dumps(payload, indent=2)

--- a/src/windows_mcp/uia/core.py
+++ b/src/windows_mcp/uia/core.py
@@ -649,6 +649,9 @@ class DisplayInfo:
     device_name: str
     rect: "Rect"
     primary: bool
+    work_rect: "Rect | None" = None
+    effective_dpi: int | None = None
+    scale: float | None = None
 
 
 class _MonitorInfoExW(ctypes.Structure):
@@ -670,6 +673,24 @@ class _DisplayDeviceW(ctypes.Structure):
         ("DeviceID", ctypes.wintypes.WCHAR * 128),
         ("DeviceKey", ctypes.wintypes.WCHAR * 128),
     ]
+
+
+def _get_monitor_effective_dpi(hMonitor: int) -> tuple[int | None, float | None]:
+    try:
+        dpi_x = ctypes.c_uint()
+        dpi_y = ctypes.c_uint()
+        result = ctypes.windll.shcore.GetDpiForMonitor(
+            ctypes.c_void_p(hMonitor),
+            0,
+            ctypes.byref(dpi_x),
+            ctypes.byref(dpi_y),
+        )
+        if result != 0:
+            return None, None
+        dpi = int(dpi_x.value)
+        return dpi, round(dpi / 96, 6)
+    except Exception:
+        return None, None
 
 
 def _active_display_indices() -> Dict[str, int]:
@@ -729,6 +750,12 @@ def GetDisplays() -> List[DisplayInfo]:
                 info.rcMonitor.right,
                 info.rcMonitor.bottom,
             )
+            work_rect = Rect(
+                info.rcWork.left,
+                info.rcWork.top,
+                info.rcWork.right,
+                info.rcWork.bottom,
+            )
             device_name = info.szDevice
             index = display_indices.get(device_name.upper(), next_fallback_index())
             primary = bool(info.dwFlags & 1)
@@ -739,9 +766,11 @@ def GetDisplays() -> List[DisplayInfo]:
                 lprcMonitor.contents.right,
                 lprcMonitor.contents.bottom,
             )
+            work_rect = None
             index = next_fallback_index()
             device_name = f"DISPLAY{index}"
             primary = False
+        effective_dpi, scale = _get_monitor_effective_dpi(hMonitor)
 
         displays.append(
             DisplayInfo(
@@ -749,6 +778,9 @@ def GetDisplays() -> List[DisplayInfo]:
                 device_name=device_name,
                 rect=rect,
                 primary=primary,
+                work_rect=work_rect,
+                effective_dpi=effective_dpi,
+                scale=scale,
             )
         )
         return 1

--- a/tests/test_display_inventory_tool.py
+++ b/tests/test_display_inventory_tool.py
@@ -1,0 +1,69 @@
+import asyncio
+import json
+from collections.abc import Callable
+
+from windows_mcp.tools import display as display_tool_module
+from windows_mcp.uia import DisplayInfo, Rect
+
+
+class FakeMCP:
+    def __init__(self) -> None:
+        self.tools: dict[str, Callable] = {}
+
+    def tool(self, *, name: str, **kwargs: object) -> Callable:
+        def decorator(func: Callable) -> Callable:
+            self.tools[name] = func
+            return func
+
+        return decorator
+
+
+class FakeDesktop:
+    def get_displays(self) -> list[DisplayInfo]:
+        return [
+            DisplayInfo(
+                index=0,
+                device_name="\\\\.\\DISPLAY1",
+                rect=Rect(0, 0, 1920, 1080),
+                primary=True,
+                work_rect=Rect(0, 0, 1920, 1040),
+                effective_dpi=144,
+                scale=1.5,
+            )
+        ]
+
+
+def test_display_inventory_returns_display_dpi_metadata() -> None:
+    mcp = FakeMCP()
+    display_tool_module.register(mcp, get_desktop=FakeDesktop, get_analytics=lambda: None)
+
+    result = json.loads(asyncio.run(mcp.tools["DisplayInventory"]()))
+
+    assert result == {
+        "displays": [
+            {
+                "index": 0,
+                "device_name": "\\\\.\\DISPLAY1",
+                "primary": True,
+                "rect": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1920,
+                    "bottom": 1080,
+                    "width": 1920,
+                    "height": 1080,
+                },
+                "work_rect": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1920,
+                    "bottom": 1040,
+                    "width": 1920,
+                    "height": 1040,
+                },
+                "effective_dpi": 144,
+                "scale": 1.5,
+            }
+        ],
+        "count": 1,
+    }


### PR DESCRIPTION
## Summary

Adds a read-only `DisplayInventory` tool that reports active display layout and DPI metadata:

- display index and device name;
- monitor rectangle in virtual-screen coordinates;
- work-area rectangle;
- primary flag;
- effective DPI and scale where available.

## Motivation

Coordinate-sensitive automation needs evidence of the active display layout and scale. Windows-MCP already has internal monitor enumeration for screenshot filtering, but callers do not currently have a direct inventory tool to prove DPI/scale before running desktop workflows.

Issue: #320

## Testing

Focused checks passed:

```text
uv run pytest tests/test_display_inventory_tool.py
uv run ruff check src/windows_mcp/uia/core.py src/windows_mcp/tools/display.py src/windows_mcp/tools/__init__.py tests/test_display_inventory_tool.py
```

Focused pytest result:

```text
1 passed
```

Full repository pytest was also run and still shows the pre-existing baseline failures unrelated to this PR:

```text
uv run pytest
# 319 passed, 3 failed in tests/test_iserror_compliance.py due missing shell/clipboard/registry exported tool functions
```

## Notes

This PR only covers display/DPI inventory. Evidence-grade screenshot metadata and exact waits should remain separate reviewable changes if maintainers want them. No local planning documents or private consumer details are included.