### PR TITLE
docs: add Autohand Code MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,18 @@ args=[
 </details>
 
 <details>
+  <summary>Install in Autohand Code</summary>
+
+  Add the published stdio server from a Windows terminal:
+
+  ```shell
+  autohand mcp add windows-mcp uvx windows-mcp serve
+  ```
+
+  Add `--scope project` after `add` to keep the server configuration in the current project. See [Autohand Code](https://github.com/autohandai/code-cli/) for current installation and CLI details.
+</details>
+
+<details>
   <summary>Install in Claude Code</summary>
 
   1. Install [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview):


### PR DESCRIPTION
Adds Autohand Code to the existing client-specific installation list. The command uses the published uvx windows-mcp serve entry point already documented for Claude, Gemini, Codex, Qwen, and Perplexity.

The note also includes the project-scoped option.

Verification:
- Checked the stdio command against the current Autohand Code MCP CLI
- Ran git diff --check

This is a documentation-only change; Windows automation behavior is unchanged.