### PR TITLE
Add explicit-start drag support to Move

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,7 +691,10 @@ MCP Client can access the following tools to interact with Windows:
 - `Click`: Click on the screen at the given coordinates.
 - `Type`: Type text on an element (optionally clears existing text).
 - `Scroll`: Scroll vertically or horizontally on the window or specific regions.
-- `Move`: Move mouse pointer or drag (set drag=True) to coordinates.
+- `Move`: Move mouse pointer or drag (set drag=True) to coordinates. For deterministic
+  drag, set `from_loc=[x, y]` with `drag=True` to press at an explicit start point and
+  release at `loc` in one tool call. Optional `duration` adds bounded intermediate
+  movement.
 - `Shortcut`: Press keyboard shortcuts (`Ctrl+c`, `Alt+Tab`, etc).
 - `Wait`: Pause for a defined duration.
 - `WaitFor`: Wait until text, an active window, an element, or a focused element appears by polling UI state inside one tool call.

--- a/src/windows_mcp/desktop/service.py
+++ b/src/windows_mcp/desktop/service.py
@@ -786,24 +786,31 @@ class Desktop:
             raise ValueError("duration must be between 0 and 10 seconds")
         return effective_duration
 
+    @staticmethod
+    def _normalize_drag_point(value: object, name: str) -> tuple[int, int]:
+        if not isinstance(value, (list, tuple)) or len(value) != 2:
+            raise ValueError(f"{name} must be a list or tuple of exactly 2 integers [x, y]")
+        x, y = value
+        if any(isinstance(item, bool) or not isinstance(item, int) for item in (x, y)):
+            raise ValueError(f"{name} must contain exactly 2 integers")
+        return x, y
+
     def drag(
         self,
         loc: tuple[int, int] | list[int],
         from_loc: tuple[int, int] | list[int] | None = None,
         duration: float | int | str | None = None,
     ) -> dict[str, object]:
-        if isinstance(loc, list):
-            x, y = loc[0], loc[1]
-        else:
-            x, y = loc
+        x, y = self._normalize_drag_point(loc, "loc")
+        normalized_from_loc = (
+            None if from_loc is None else self._normalize_drag_point(from_loc, "from_loc")
+        )
         effective_duration = self._normalize_drag_duration(duration)
         sleep(0.5)
-        if from_loc is None:
+        if normalized_from_loc is None:
             cx, cy = uia.GetCursorPos()
-        elif isinstance(from_loc, list):
-            cx, cy = from_loc[0], from_loc[1]
         else:
-            cx, cy = from_loc
+            cx, cy = normalized_from_loc
         uia.DragDrop(cx, cy, x, y, moveSpeed=1, duration=effective_duration)
         return {
             "start": [cx, cy],

--- a/src/windows_mcp/desktop/service.py
+++ b/src/windows_mcp/desktop/service.py
@@ -23,6 +23,7 @@ from markdownify import markdownify
 from fuzzywuzzy import process
 from time import sleep, time, perf_counter
 from psutil import Process
+import math
 import win32process
 import win32gui
 import win32con
@@ -770,14 +771,45 @@ class Desktop:
                 return 'Invalid type. Use "horizontal" or "vertical".'
         return None
 
-    def drag(self, loc: tuple[int, int] | list[int]):
+    def _normalize_drag_duration(self, duration: float | int | str | None) -> float | None:
+        if duration is None:
+            return None
+        if isinstance(duration, bool):
+            raise ValueError("duration must be a finite number of seconds")
+        try:
+            effective_duration = float(duration)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("duration must be a finite number of seconds") from exc
+        if not math.isfinite(effective_duration):
+            raise ValueError("duration must be a finite number of seconds")
+        if effective_duration < 0 or effective_duration > 10:
+            raise ValueError("duration must be between 0 and 10 seconds")
+        return effective_duration
+
+    def drag(
+        self,
+        loc: tuple[int, int] | list[int],
+        from_loc: tuple[int, int] | list[int] | None = None,
+        duration: float | int | str | None = None,
+    ) -> dict[str, object]:
         if isinstance(loc, list):
             x, y = loc[0], loc[1]
         else:
             x, y = loc
+        effective_duration = self._normalize_drag_duration(duration)
         sleep(0.5)
-        cx, cy = uia.GetCursorPos()
-        uia.DragDrop(cx, cy, x, y, moveSpeed=1)
+        if from_loc is None:
+            cx, cy = uia.GetCursorPos()
+        elif isinstance(from_loc, list):
+            cx, cy = from_loc[0], from_loc[1]
+        else:
+            cx, cy = from_loc
+        uia.DragDrop(cx, cy, x, y, moveSpeed=1, duration=effective_duration)
+        return {
+            "start": [cx, cy],
+            "end": [x, y],
+            "duration": effective_duration,
+        }
 
     def move(self, loc: tuple[int, int]):
         x, y = loc
@@ -931,7 +963,9 @@ class Desktop:
                 sleep(self._UIA_RETRY_SLEEP_MS / 1000.0)
                 continue
         if last_error is not None:
-            logger.error(f"Error in get_active_window after {self._UIA_RETRIES} retries: {last_error}")
+            logger.error(
+                f"Error in get_active_window after {self._UIA_RETRIES} retries: {last_error}"
+            )
         return None
 
     def get_foreground_window(self) -> uia.Control | None:

--- a/src/windows_mcp/tools/input.py
+++ b/src/windows_mcp/tools/input.py
@@ -44,6 +44,25 @@ def _as_loc(value: list | str | None) -> list | None:
     return json.loads(value)
 
 
+def _as_point(value: object, name: str) -> list[int]:
+    if not isinstance(value, list) or len(value) != 2:
+        raise ValueError(f"{name} must be a list of exactly 2 integers [x, y]")
+    parsed = []
+    for item in value:
+        if isinstance(item, bool):
+            raise ValueError(f"{name} must contain integers, not booleans")
+        if isinstance(item, int):
+            parsed.append(item)
+            continue
+        if isinstance(item, str):
+            stripped = item.strip()
+            if stripped and stripped.lstrip("+-").isdigit():
+                parsed.append(int(stripped))
+                continue
+        raise ValueError(f"{name} must contain exactly 2 integers")
+    return parsed
+
+
 def _text_matches(value: object | None, expected: str | None) -> bool:
     if expected is None:
         return True
@@ -301,14 +320,16 @@ def register(
         description=(
             "Moves mouse cursor to coordinates [x, y] or passing a UI element's label/id. "
             "Set drag=True to perform a drag-and-drop operation from the current mouse position "
-            "to the target coordinates. Default (drag=False) is a simple cursor move (hover). "
+            "to the target coordinates, or provide from_loc=[x, y] to make the drag explicit-start "
+            "and atomic in one tool call. Optional duration controls bounded intermediate movement. "
+            "Default (drag=False) is a simple cursor move (hover). "
             "Provide either loc or label."
         ),
         annotations=ToolAnnotations(
             title="Move",
             readOnlyHint=False,
-            destructiveHint=False,
-            idempotentHint=True,
+            destructiveHint=True,
+            idempotentHint=False,
             openWorldHint=False,
         ),
     )
@@ -317,21 +338,50 @@ def register(
         loc: list[int] | str | None = None,
         label: int | None = None,
         drag: bool | str = False,
+        from_loc: list[int] | str | None = None,
+        duration: float | int | str | None = None,
         ctx: Context = None,
     ) -> str:
         desktop = get_desktop()
         loc = _as_loc(loc)
-        drag = drag is True or (isinstance(drag, str) and drag.lower() == "true")
+        from_loc = _as_loc(from_loc)
+        drag = _as_bool(drag)
         if loc is None and label is None:
             raise ValueError("Either loc or label must be provided.")
         if label is not None:
             loc = _resolve_label(desktop, label)
-        if len(loc) != 2:
+        if not isinstance(loc, list) or len(loc) != 2:
             raise ValueError("loc must be a list of exactly 2 integers [x, y]")
+        if from_loc is not None and (not isinstance(from_loc, list) or len(from_loc) != 2):
+            raise ValueError("from_loc must be a list of exactly 2 integers [x, y]")
+        has_drag_only_options = any(
+            value is not None
+            for value in (
+                from_loc,
+                duration,
+            )
+        )
+        if has_drag_only_options and not drag:
+            raise ValueError("from_loc and duration require drag=True")
+        if drag:
+            loc = _as_point(loc, "loc")
+            if from_loc is not None:
+                from_loc = _as_point(from_loc, "from_loc")
         x, y = loc[0], loc[1]
         if drag:
-            desktop.drag(loc)
-            return f"Dragged to ({x},{y})."
+            result = desktop.drag(
+                loc,
+                from_loc=from_loc,
+                duration=duration,
+            )
+            start_x, start_y = result["start"]
+            effective_duration = result["duration"]
+            if effective_duration is None:
+                return f"Dragged from ({start_x},{start_y}) to ({x},{y})."
+            return (
+                f"Dragged from ({start_x},{start_y}) to ({x},{y}) "
+                f"over {effective_duration:.3f} seconds."
+            )
         else:
             desktop.move(loc)
             return f"Moved the mouse pointer to ({x},{y})."

--- a/src/windows_mcp/uia/core.py
+++ b/src/windows_mcp/uia/core.py
@@ -11,6 +11,7 @@ uiautomation is shared under the Apache Licene 2.0.
 This means that the code can be freely copied and distributed, and costs nothing to use.
 """
 
+import math
 import os
 import sys
 import time
@@ -488,15 +489,14 @@ def MoveToDuration(x: int, y: int, duration: float, waitTime: float = OPERATION_
         time.sleep(waitTime)
         return
 
-    stepCount = max(1, min(200, int(duration / 0.01)))
+    stepCount = max(2, min(200, math.ceil(duration / 0.01)))
     interval = duration / stepCount
-    for i in range(1, stepCount):
+    for i in range(1, stepCount + 1):
         ratio = i / stepCount
         cx = curX + round((x - curX) * ratio)
         cy = curY + round((y - curY) * ratio)
         SetCursorPos(cx, cy)
         time.sleep(interval)
-    SetCursorPos(x, y)
     time.sleep(waitTime)
 
 

--- a/src/windows_mcp/uia/core.py
+++ b/src/windows_mcp/uia/core.py
@@ -478,6 +478,28 @@ def MoveTo(x: int, y: int, moveSpeed: float = 1, waitTime: float = OPERATION_WAI
     time.sleep(waitTime)
 
 
+def MoveToDuration(x: int, y: int, duration: float, waitTime: float = OPERATION_WAIT_TIME) -> None:
+    """
+    Simulate mouse move to point x, y over a bounded duration from current cursor.
+    """
+    curX, curY = GetCursorPos()
+    if duration <= 0:
+        SetCursorPos(x, y)
+        time.sleep(waitTime)
+        return
+
+    stepCount = max(1, min(200, int(duration / 0.01)))
+    interval = duration / stepCount
+    for i in range(1, stepCount):
+        ratio = i / stepCount
+        cx = curX + round((x - curX) * ratio)
+        cy = curY + round((y - curY) * ratio)
+        SetCursorPos(cx, cy)
+        time.sleep(interval)
+    SetCursorPos(x, y)
+    time.sleep(waitTime)
+
+
 def DragDrop(
     x1: int,
     y1: int,
@@ -485,6 +507,7 @@ def DragDrop(
     y2: int,
     moveSpeed: float = 1,
     waitTime: float = OPERATION_WAIT_TIME,
+    duration: float | None = None,
 ) -> None:
     """
     Simulate mouse left button drag from point x1, y1 drop to point x2, y2.
@@ -494,9 +517,20 @@ def DragDrop(
     y2: int.
     moveSpeed: float, 1 normal speed, < 1 move slower, > 1 move faster.
     waitTime: float.
+    duration: optional seconds for bounded intermediate movement.
     """
-    PressMouse(x1, y1, 0.05)
-    MoveTo(x2, y2, moveSpeed, 0.05)
+    try:
+        PressMouse(x1, y1, 0.05)
+        if duration is None:
+            MoveTo(x2, y2, moveSpeed, 0.05)
+        else:
+            MoveToDuration(x2, y2, duration, 0.05)
+    except BaseException as move_error:
+        try:
+            ReleaseMouse(waitTime)
+        except BaseException as release_error:
+            raise release_error from move_error
+        raise
     ReleaseMouse(waitTime)
 
 

--- a/tests/test_deterministic_drag_core.py
+++ b/tests/test_deterministic_drag_core.py
@@ -83,6 +83,23 @@ def test_move_to_duration_emits_intermediate_and_final_positions(
     assert positions[-1] == (30, 0)
 
 
+def test_move_to_duration_honors_short_positive_duration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    positions: list[tuple[int, int]] = []
+    sleeps: list[float] = []
+
+    monkeypatch.setattr(core, "GetCursorPos", lambda: (0, 0))
+    monkeypatch.setattr(core, "SetCursorPos", lambda x, y: positions.append((x, y)))
+    monkeypatch.setattr(core.time, "sleep", sleeps.append)
+
+    core.MoveToDuration(10, 0, duration=0.005, waitTime=0.03)
+
+    assert positions == [(5, 0), (10, 0)]
+    assert sum(sleeps[:-1]) == pytest.approx(0.005)
+    assert sleeps[-1] == 0.03
+
+
 def test_move_to_duration_zero_duration_sets_final_position(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_deterministic_drag_core.py
+++ b/tests/test_deterministic_drag_core.py
@@ -1,0 +1,97 @@
+import pytest
+
+from windows_mcp.uia import core
+
+
+def test_dragdrop_releases_mouse_after_move_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    def press_mouse(x: int, y: int, wait_time: float) -> None:
+        calls.append(f"press:{x},{y},{wait_time}")
+
+    def move_to(x: int, y: int, move_speed: float, wait_time: float) -> None:
+        calls.append(f"move:{x},{y},{move_speed},{wait_time}")
+        raise RuntimeError("move failed")
+
+    def release_mouse(wait_time: float) -> None:
+        calls.append(f"release:{wait_time}")
+
+    monkeypatch.setattr(core, "PressMouse", press_mouse)
+    monkeypatch.setattr(core, "MoveTo", move_to)
+    monkeypatch.setattr(core, "ReleaseMouse", release_mouse)
+
+    with pytest.raises(RuntimeError, match="move failed"):
+        core.DragDrop(10, 20, 30, 40, moveSpeed=2, waitTime=0.3)
+
+    assert calls == ["press:10,20,0.05", "move:30,40,2,0.05", "release:0.3"]
+
+
+def test_dragdrop_releases_mouse_after_press_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    def press_mouse(x: int, y: int, wait_time: float) -> None:
+        calls.append(f"press:{x},{y},{wait_time}")
+        raise RuntimeError("press wait interrupted")
+
+    monkeypatch.setattr(core, "PressMouse", press_mouse)
+    monkeypatch.setattr(
+        core,
+        "MoveTo",
+        lambda *args: pytest.fail("movement must not start after press failure"),
+    )
+    monkeypatch.setattr(
+        core,
+        "ReleaseMouse",
+        lambda wait_time: calls.append(f"release:{wait_time}"),
+    )
+
+    with pytest.raises(RuntimeError, match="press wait interrupted"):
+        core.DragDrop(10, 20, 30, 40, waitTime=0.3)
+
+    assert calls == ["press:10,20,0.05", "release:0.3"]
+
+
+def test_dragdrop_uses_duration_path_and_releases(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    monkeypatch.setattr(core, "PressMouse", lambda *args: calls.append(f"press:{args}"))
+    monkeypatch.setattr(core, "MoveTo", lambda *args: calls.append(f"move:{args}"))
+    monkeypatch.setattr(core, "MoveToDuration", lambda *args: calls.append(f"duration:{args}"))
+    monkeypatch.setattr(core, "ReleaseMouse", lambda *args: calls.append(f"release:{args}"))
+
+    core.DragDrop(1, 2, 3, 4, moveSpeed=5, waitTime=0.6, duration=0.25)
+
+    assert calls == [
+        "press:(1, 2, 0.05)",
+        "duration:(3, 4, 0.25, 0.05)",
+        "release:(0.6,)",
+    ]
+
+
+def test_move_to_duration_emits_intermediate_and_final_positions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    positions: list[tuple[int, int]] = []
+
+    monkeypatch.setattr(core, "GetCursorPos", lambda: (0, 0))
+    monkeypatch.setattr(core, "SetCursorPos", lambda x, y: positions.append((x, y)))
+    monkeypatch.setattr(core.time, "sleep", lambda seconds: None)
+
+    core.MoveToDuration(30, 0, duration=0.04, waitTime=0)
+
+    assert len(positions) > 1
+    assert positions[-1] == (30, 0)
+
+
+def test_move_to_duration_zero_duration_sets_final_position(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    positions: list[tuple[int, int]] = []
+
+    monkeypatch.setattr(core, "GetCursorPos", lambda: (10, 10))
+    monkeypatch.setattr(core, "SetCursorPos", lambda x, y: positions.append((x, y)))
+    monkeypatch.setattr(core.time, "sleep", lambda seconds: None)
+
+    core.MoveToDuration(10, 10, duration=0, waitTime=0)
+
+    assert positions == [(10, 10)]

--- a/tests/test_deterministic_drag_desktop.py
+++ b/tests/test_deterministic_drag_desktop.py
@@ -82,3 +82,42 @@ def test_desktop_drag_rejects_boolean_duration_before_input(
 
     with pytest.raises(ValueError, match="finite"):
         desktop.drag([1, 2], from_loc=[3, 4], duration=duration)
+
+
+@pytest.mark.parametrize(
+    ("argument", "value"),
+    [
+        ("loc", [1]),
+        ("loc", [1, True]),
+        ("loc", [1, 2.0]),
+        ("loc", [1, "2"]),
+        ("from_loc", (3,)),
+        ("from_loc", (3, False)),
+        ("from_loc", (3.0, 4)),
+        ("from_loc", ("3", 4)),
+    ],
+)
+def test_desktop_drag_rejects_invalid_points_before_waiting_or_input(
+    argument: str,
+    value: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    desktop = _desktop()
+    monkeypatch.setattr(
+        service,
+        "sleep",
+        lambda seconds: pytest.fail("point must be rejected before waiting"),
+    )
+    monkeypatch.setattr(
+        service.uia,
+        "DragDrop",
+        lambda *args, **kwargs: pytest.fail("point must be rejected before input"),
+    )
+    kwargs: dict[str, object] = {
+        "loc": [1, 2],
+        "from_loc": [3, 4],
+        argument: value,
+    }
+
+    with pytest.raises(ValueError, match=argument):
+        desktop.drag(**kwargs)

--- a/tests/test_deterministic_drag_desktop.py
+++ b/tests/test_deterministic_drag_desktop.py
@@ -1,0 +1,84 @@
+import pytest
+
+from windows_mcp.desktop import service
+from windows_mcp.desktop.service import Desktop
+
+
+def _desktop() -> Desktop:
+    desktop = Desktop.__new__(Desktop)
+    desktop.desktop_state = None
+    return desktop
+
+
+def test_desktop_drag_uses_explicit_start_and_duration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[int, int, int, int, int, float | None]] = []
+    desktop = _desktop()
+
+    monkeypatch.setattr(service, "sleep", lambda seconds: None)
+    monkeypatch.setattr(
+        service.uia,
+        "DragDrop",
+        lambda x1, y1, x2, y2, moveSpeed=1, duration=None: calls.append(
+            (x1, y1, x2, y2, moveSpeed, duration)
+        ),
+    )
+
+    result = desktop.drag(
+        [100, 200],
+        from_loc=[10, 20],
+        duration="0.25",
+    )
+
+    assert calls == [(10, 20, 100, 200, 1, 0.25)]
+    assert result["start"] == [10, 20]
+    assert result["end"] == [100, 200]
+    assert result["duration"] == 0.25
+
+
+def test_desktop_drag_legacy_start_uses_current_cursor(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[int, int, int, int]] = []
+    desktop = _desktop()
+
+    monkeypatch.setattr(service, "sleep", lambda seconds: None)
+    monkeypatch.setattr(service.uia, "GetCursorPos", lambda: (7, 8))
+    monkeypatch.setattr(
+        service.uia,
+        "DragDrop",
+        lambda x1, y1, x2, y2, **kwargs: calls.append((x1, y1, x2, y2)),
+    )
+
+    result = desktop.drag((30, 40))
+
+    assert calls == [(7, 8, 30, 40)]
+    assert result["start"] == [7, 8]
+    assert result["duration"] is None
+
+
+def test_desktop_drag_rejects_non_finite_duration() -> None:
+    desktop = _desktop()
+
+    with pytest.raises(ValueError, match="finite"):
+        desktop.drag([1, 2], from_loc=[3, 4], duration="nan")
+
+
+@pytest.mark.parametrize("duration", [True, False])
+def test_desktop_drag_rejects_boolean_duration_before_input(
+    duration: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    desktop = _desktop()
+    monkeypatch.setattr(
+        service,
+        "sleep",
+        lambda seconds: pytest.fail("duration must be rejected before waiting"),
+    )
+    monkeypatch.setattr(
+        service.uia,
+        "DragDrop",
+        lambda *args, **kwargs: pytest.fail("duration must be rejected before input"),
+    )
+
+    with pytest.raises(ValueError, match="finite"):
+        desktop.drag([1, 2], from_loc=[3, 4], duration=duration)

--- a/tests/test_deterministic_drag_input.py
+++ b/tests/test_deterministic_drag_input.py
@@ -1,0 +1,152 @@
+import asyncio
+from collections.abc import Callable
+
+import pytest
+
+from windows_mcp.tools.input import register
+
+
+class FakeMCP:
+    def __init__(self) -> None:
+        self.tools: dict[str, Callable] = {}
+        self.tool_options: dict[str, dict[str, object]] = {}
+
+    def tool(self, *, name: str, **kwargs: object) -> Callable:
+        self.tool_options[name] = kwargs
+
+        def decorator(func: Callable) -> Callable:
+            self.tools[name] = func
+            return func
+
+        return decorator
+
+
+class FakeDesktop:
+    def __init__(self) -> None:
+        self.desktop_state = object()
+        self.move_calls: list[list[int]] = []
+        self.drag_calls: list[dict[str, object]] = []
+
+    def move(self, loc: list[int]) -> None:
+        self.move_calls.append(loc)
+
+    def drag(self, loc: list[int], **kwargs: object) -> dict[str, object]:
+        self.drag_calls.append({"loc": loc, **kwargs})
+        return {
+            "start": kwargs.get("from_loc") or [1, 2],
+            "end": loc,
+            "duration": 0.25 if kwargs.get("duration") is not None else None,
+        }
+
+
+def _tools(desktop: FakeDesktop) -> dict[str, Callable]:
+    mcp = FakeMCP()
+    register(mcp, get_desktop=lambda: desktop, get_analytics=lambda: None)
+    return mcp.tools
+
+
+def test_move_tool_preserves_legacy_move_behavior() -> None:
+    desktop = FakeDesktop()
+    result = asyncio.run(_tools(desktop)["Move"](loc=[10, 20]))
+
+    assert result == "Moved the mouse pointer to (10,20)."
+    assert desktop.move_calls == [[10, 20]]
+    assert desktop.drag_calls == []
+
+
+def test_move_tool_annotations_cover_drag_side_effects() -> None:
+    desktop = FakeDesktop()
+    mcp = FakeMCP()
+    register(mcp, get_desktop=lambda: desktop, get_analytics=lambda: None)
+
+    annotations = mcp.tool_options["Move"]["annotations"]
+
+    assert annotations.destructiveHint is True
+    assert annotations.idempotentHint is False
+
+
+def test_move_tool_accepts_explicit_drag_start_list() -> None:
+    desktop = FakeDesktop()
+    result = asyncio.run(
+        _tools(desktop)["Move"](
+            loc=[100, 200],
+            drag=True,
+            from_loc=[10, 20],
+            duration=0.25,
+        )
+    )
+
+    assert result == "Dragged from (10,20) to (100,200) over 0.250 seconds."
+    assert desktop.drag_calls == [
+        {
+            "loc": [100, 200],
+            "from_loc": [10, 20],
+            "duration": 0.25,
+        }
+    ]
+
+
+def test_move_tool_accepts_explicit_drag_start_json_string() -> None:
+    desktop = FakeDesktop()
+    result = asyncio.run(
+        _tools(desktop)["Move"](
+            loc="[100, 200]",
+            drag="true",
+            from_loc="[10, 20]",
+        )
+    )
+
+    assert result == "Dragged from (10,20) to (100,200)."
+    assert desktop.drag_calls[0]["from_loc"] == [10, 20]
+
+
+def test_move_tool_rejects_invalid_from_loc() -> None:
+    with pytest.raises(ValueError, match="from_loc"):
+        asyncio.run(_tools(FakeDesktop())["Move"](loc=[100, 200], drag=True, from_loc=[10]))
+
+
+@pytest.mark.parametrize(
+    ("argument", "value"),
+    [
+        ("from_loc", [True, 20]),
+        ("from_loc", [10.5, 20]),
+        ("loc", [100, False]),
+        ("loc", [100, "20.5"]),
+    ],
+)
+def test_move_tool_rejects_non_integer_drag_points_before_input(
+    argument: str,
+    value: list[object],
+) -> None:
+    desktop = FakeDesktop()
+    kwargs: dict[str, object] = {
+        "loc": [100, 200],
+        "drag": True,
+        "from_loc": [10, 20],
+        argument: value,
+    }
+
+    with pytest.raises(ValueError, match=argument):
+        asyncio.run(_tools(desktop)["Move"](**kwargs))
+
+    assert desktop.drag_calls == []
+
+
+def test_move_tool_normalizes_string_drag_coordinates() -> None:
+    desktop = FakeDesktop()
+
+    asyncio.run(
+        _tools(desktop)["Move"](
+            loc=["100", "200"],
+            drag=True,
+            from_loc=["10", "+20"],
+        )
+    )
+
+    assert desktop.drag_calls[0]["loc"] == [100, 200]
+    assert desktop.drag_calls[0]["from_loc"] == [10, 20]
+
+
+def test_move_tool_rejects_drag_options_without_drag() -> None:
+    with pytest.raises(ValueError, match="require drag=True"):
+        asyncio.run(_tools(FakeDesktop())["Move"](loc=[100, 200], from_loc=[10, 20]))


### PR DESCRIPTION
## Summary

- extend the existing `Move` tool with optional `from_loc` and `duration` parameters
- preserve the current-cursor drag path when the new parameters are omitted
- validate explicit drag coordinates and duration before mouse input
- guarantee mouse-button release when press or movement raises
- mark `Move` as destructive and non-idempotent because it can perform drag-and-drop

## Why

An agent that knows both drag endpoints currently needs separate move and drag calls. The cursor can change between those calls, so the actual source is not deterministic. An explicit source makes the operation atomic while retaining the existing API as the default.

## API

```python
Move(loc=[600, 400], drag=True, from_loc=[300, 200], duration=0.25)
```

`from_loc` and `duration` are additive and require `drag=True`. Duration is bounded to 0–10 seconds. Omitting them preserves the existing behavior.

## Scope

This PR contains only deterministic drag behavior, its tests, and the corresponding README update. It intentionally does not include foreground-window guards or other automation capabilities.

## Testing

- `ruff check` on all changed Python files: passed
- `ruff format --check` on all changed Python files: passed
- focused drag tests: `30 passed`
- full suite: `348 passed, 3 failed`
- the same three `tests/test_iserror_compliance.py` import failures reproduce on unmodified `upstream/main`
- manually smoke-tested on Windows 10 at real 100% and 150% display scaling

## Dependencies

None. This branch is based directly on current `main`.

Closes #326
