### PR TITLE
Reject invalid input boolean values

### DIFF
--- a/src/windows_mcp/tools/input.py
+++ b/src/windows_mcp/tools/input.py
@@ -29,8 +29,16 @@ def _resolve_label(desktop: Any, label: int) -> list[int]:
         raise ValueError(f"Failed to find element with label {label}: {e}")
 
 
-def _as_bool(value: bool | str) -> bool:
-    return value is True or (isinstance(value, str) and value.lower() == "true")
+def _as_bool(value: bool | str, name: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().casefold()
+        if normalized == "true":
+            return True
+        if normalized == "false":
+            return False
+    raise ValueError(f"{name} must be true or false")
 
 
 def _as_loc(value: list | str | None) -> list | None:
@@ -345,7 +353,7 @@ def register(
         desktop = get_desktop()
         loc = _as_loc(loc)
         from_loc = _as_loc(from_loc)
-        drag = _as_bool(drag)
+        drag = _as_bool(drag, "drag")
         if loc is None and label is None:
             raise ValueError("Either loc or label must be provided.")
         if label is not None:
@@ -452,7 +460,7 @@ def register(
             interval=interval,
         )
         desktop = get_desktop()
-        use_dom_bool = _as_bool(use_dom)
+        use_dom_bool = _as_bool(use_dom, "use_dom")
         started_at = time.monotonic()
         deadline = started_at + timeout
         attempts = 0

--- a/tests/test_deterministic_drag_input.py
+++ b/tests/test_deterministic_drag_input.py
@@ -54,6 +54,16 @@ def test_move_tool_preserves_legacy_move_behavior() -> None:
     assert desktop.drag_calls == []
 
 
+def test_move_tool_rejects_invalid_drag_boolean_before_input() -> None:
+    desktop = FakeDesktop()
+
+    with pytest.raises(ValueError, match="drag must be true or false"):
+        asyncio.run(_tools(desktop)["Move"](loc=[10, 20], drag="tru"))
+
+    assert desktop.move_calls == []
+    assert desktop.drag_calls == []
+
+
 def test_move_tool_annotations_cover_drag_side_effects() -> None:
     desktop = FakeDesktop()
     mcp = FakeMCP()

--- a/tests/test_wait_for_tool.py
+++ b/tests/test_wait_for_tool.py
@@ -186,6 +186,22 @@ def test_wait_for_text_requires_text() -> None:
         asyncio.run(tools["WaitFor"](condition="text_exists"))
 
 
+def test_wait_for_rejects_invalid_use_dom_boolean_before_capture() -> None:
+    desktop = FakeDesktop([_state()])
+    tools = _register_tools(desktop)
+
+    with pytest.raises(ValueError, match="use_dom must be true or false"):
+        asyncio.run(
+            tools["WaitFor"](
+                condition="text_exists",
+                text="ready",
+                use_dom="tru",
+            )
+        )
+
+    assert desktop.calls == []
+
+
 def test_wait_for_timeout_reports_last_observed_state() -> None:
     desktop = FakeDesktop([_state(active_window_name="Explorer")])
     tools = _register_tools(desktop)


### PR DESCRIPTION
## Summary

- reject invalid boolean values for `Move(drag=...)` and `WaitFor(use_dom=...)`
- continue accepting native booleans and case-insensitive `"true"` / `"false"` strings
- fail before mouse input or desktop capture when a value is invalid
- add focused regression coverage for both call paths

## Root cause

The shared boolean coercion helper treated every value other than `True` or the string `"true"` as
`False`. Misspelled values such as `"tru"` therefore changed behavior silently instead of reporting
an invalid request.

## Compatibility

Existing valid boolean values remain compatible. Only values that were never valid booleans now
raise a clear `ValueError` instead of being interpreted as `False`.

## Testing

- changed-file `ruff check`: passed
- changed-file `ruff format --check`: passed
- focused tests: `19 passed`
- full suite on this branch: `354 passed, 3 failed`
- full suite on unmodified `upstream/main`: `352 passed, 3 failed`
- the same three `tests/test_iserror_compliance.py` import failures occur on unmodified
  `upstream/main`

## Dependencies and scope

None. This branch is based directly on current `main`. It does not change the public tool surface
and does not include unrelated input, wait, or drag changes.

