### PR TITLE
feat: add WINDOWS_MCP_WATCHDOG switch to disable the UIA watchdog

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -33,7 +33,8 @@
         "ANONYMIZED_TELEMETRY": "${user_config.anonymized_telemetry}",
         "WINDOWS_MCP_PROFILE_SNAPSHOT": "${user_config.profile_snapshot}",
         "WINDOWS_MCP_SCREENSHOT_BACKEND": "${user_config.screenshot_backend}",
-        "WINDOWS_MCP_DEBUG": "${user_config.debug}"
+        "WINDOWS_MCP_DEBUG": "${user_config.debug}",
+        "WINDOWS_MCP_WATCHDOG": "${user_config.watchdog}"
       }
     }
   },
@@ -65,6 +66,13 @@
       "description": "Enable debug mode to provide verbose logging for troubleshooting.",
       "required": false,
       "default": false
+    },
+    "watchdog": {
+      "type": "boolean",
+      "title": "UIA Focus WatchDog",
+      "description": "Run the UIAutomation focus watchdog that keeps the accessibility tree current. Disable if the watchdog degrades or crashes on unstable UIA environments after long uptime.",
+      "required": false,
+      "default": true
     }
   },
   "tools": [
@@ -98,7 +106,7 @@
     },
     {
       "name": "Scroll",
-      "description": "Scrolls at coordinates [x, y], a UI element's label/id, or current mouse position if loc=None. Type: vertical (default) or horizontal. Direction: up/down for vertical, left/right for horizontal. wheel_times controls amount (1 wheel ≈ 3-5 lines). Use for navigating long content, lists, and web pages."
+      "description": "Scrolls at coordinates [x, y], a UI element's label/id, or current mouse position if loc=None. Type: vertical (default) or horizontal. Direction: up/down for vertical, left/right for horizontal. wheel_times controls amount (1 wheel \u2248 3-5 lines). Use for navigating long content, lists, and web pages."
     },
     {
       "name": "Move",

--- a/src/windows_mcp/__main__.py
+++ b/src/windows_mcp/__main__.py
@@ -161,6 +161,23 @@ class OptionsMiddleware:
             await self.app(scope, receive, send)
 
 
+def _watchdog_enabled() -> bool:
+    """Whether the UIA focus WatchDog should run.
+
+    Reads the ``WINDOWS_MCP_WATCHDOG`` environment variable. Disabling values
+    (case-insensitive, whitespace-trimmed): ``off``, ``0``, ``false``, ``no``,
+    ``disabled``. Anything else, including unset, keeps the watchdog enabled so
+    the default behavior is unchanged.
+
+    Returns:
+        ``True`` when the watchdog should be started, ``False`` to skip it.
+    """
+    value = os.getenv("WINDOWS_MCP_WATCHDOG")
+    if value is None:
+        return True
+    return value.strip().lower() not in {"off", "0", "false", "no", "disabled"}
+
+
 def _build_mcp() -> FastMCP:
     """Create the MCP server instance."""
     global _mcp
@@ -171,7 +188,6 @@ def _build_mcp() -> FastMCP:
     from windows_mcp.infrastructure import PostHogAnalytics
     from windows_mcp.desktop.service import Desktop
     from windows_mcp.tools import register_all
-    from windows_mcp.watchdog.service import WatchDog
 
     @asynccontextmanager
     async def lifespan(app: FastMCP):
@@ -181,12 +197,21 @@ def _build_mcp() -> FastMCP:
         if os.getenv("ANONYMIZED_TELEMETRY", "true").lower() != "false":
             analytics = PostHogAnalytics()
         desktop = Desktop()
-        watchdog = WatchDog()
         screen_size = desktop.get_screen_size()
-        watchdog.set_focus_callback(desktop.tree.on_focus_change)
+
+        if _watchdog_enabled():
+            # Imported lazily so a disabled watchdog never loads comtypes.
+            from windows_mcp.watchdog.service import WatchDog
+
+            watchdog = WatchDog()
+            watchdog.set_focus_callback(desktop.tree.on_focus_change)
+        else:
+            watchdog = None
+            logger.debug("WatchDog disabled via WINDOWS_MCP_WATCHDOG")
 
         try:
-            watchdog.start()
+            if watchdog:
+                watchdog.start()
             await asyncio.sleep(1)  # Simulate startup latency
             logger.debug("Server started, entering main loop")
             yield

--- a/tests/test_watchdog_toggle.py
+++ b/tests/test_watchdog_toggle.py
@@ -1,0 +1,21 @@
+"""Tests for the WINDOWS_MCP_WATCHDOG opt-out switch (issue #332)."""
+
+from windows_mcp import __main__ as wm
+
+
+class TestWatchdogEnabled:
+    def test_enabled_by_default_when_unset(self, monkeypatch):
+        monkeypatch.delenv("WINDOWS_MCP_WATCHDOG", raising=False)
+        assert wm._watchdog_enabled() is True
+
+    def test_disabling_values_turn_it_off(self, monkeypatch):
+        for value in ["off", "0", "false", "no", "disabled", "OFF", "  False  ", "No"]:
+            monkeypatch.setenv("WINDOWS_MCP_WATCHDOG", value)
+            assert wm._watchdog_enabled() is False, value
+
+    def test_other_values_keep_it_on(self, monkeypatch):
+        # Anything not in the disabling set (including empty string) keeps the
+        # default-on behavior unchanged.
+        for value in ["on", "1", "true", "yes", "enabled", ""]:
+            monkeypatch.setenv("WINDOWS_MCP_WATCHDOG", value)
+            assert wm._watchdog_enabled() is True, value


### PR DESCRIPTION
## Summary

Adds a `WINDOWS_MCP_WATCHDOG` switch (and a matching Claude Desktop toggle) so users can turn off the UIA focus watchdog.

## Why this matters

Per #332, after long uptime the UIA watchdog can degrade (`HandleFocusChangedEvent` failing on every focus event) and eventually a `comtypes.client.PumpEvents` "Catastrophic failure" takes down the whole stdio MCP process, showing "Server disconnected". The reporter notes there is currently no supported way to disable the watchdog: `WatchDog()` is constructed unconditionally in the server lifespan, so users on unstable UIA environments have no workaround short of restarting the extension.

## Changes

- `_watchdog_enabled()` reads `WINDOWS_MCP_WATCHDOG` and returns `False` for the disabling values `off`, `0`, `false`, `no`, `disabled` (case-insensitive, trimmed); anything else, including unset, keeps the watchdog on so default behavior is unchanged.
- The lifespan gates watchdog construction and startup on `_watchdog_enabled()`, leaving `watchdog = None` when disabled. The existing `if watchdog:` shutdown guard already tolerates `None`. The `from windows_mcp.watchdog.service import WatchDog` import moves inside the enabled branch, so a disabled watchdog never loads `comtypes`.
- `manifest.json` exposes a `watchdog` boolean `user_config` (default `true`) wired to `WINDOWS_MCP_WATCHDOG`, mirroring the existing `debug` / `screenshot_backend` toggles.

## Testing

`pytest tests/test_watchdog_toggle.py` (3 tests) covering default-on when unset, each disabling value turning it off, and other values keeping it on. `ruff format --check` and `ruff check` pass.

This is the supported opt-out (the issue's suggested fix #3). The root-cause COM crash-isolation work needs a Windows UIA host to reproduce, so this refs #332 rather than closing it.

Refs #332
