### PR TITLE
Reject invalid WaitFor timing values

### DIFF
--- a/src/windows_mcp/tools/input.py
+++ b/src/windows_mcp/tools/input.py
@@ -1,6 +1,7 @@
 """Input tools — Click, Type, Scroll, Move, Shortcut, Wait, WaitFor."""
 
 import json
+import math
 import time
 from collections.abc import Callable, Iterator
 from typing import Any, Literal
@@ -39,6 +40,11 @@ def _as_bool(value: bool | str, name: str) -> bool:
         if normalized == "false":
             return False
     raise ValueError(f"{name} must be true or false")
+
+
+def _validate_finite_number(value: object, name: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value):
+        raise ValueError(f"{name} must be a finite number")
 
 
 def _as_loc(value: list | str | None) -> list | None:
@@ -166,6 +172,9 @@ def _validate_wait_for_args(
     timeout: float,
     interval: float,
 ) -> WaitForCondition:
+    _validate_finite_number(timeout, "timeout")
+    _validate_finite_number(interval, "interval")
+
     normalized = condition.strip().lower().replace("-", "_")
     aliases = {
         "text": "text_exists",

--- a/tests/test_wait_for_tool.py
+++ b/tests/test_wait_for_tool.py
@@ -202,6 +202,31 @@ def test_wait_for_rejects_invalid_use_dom_boolean_before_capture() -> None:
     assert desktop.calls == []
 
 
+@pytest.mark.parametrize(
+    ("argument", "value"),
+    [
+        ("timeout", True),
+        ("interval", False),
+        ("timeout", float("nan")),
+        ("interval", float("inf")),
+    ],
+)
+def test_wait_for_rejects_invalid_timing_before_capture(argument: str, value: object) -> None:
+    desktop = FakeDesktop([_state()])
+    tools = _register_tools(desktop)
+
+    with pytest.raises(ValueError, match=rf"{argument} must be a finite number"):
+        asyncio.run(
+            tools["WaitFor"](
+                condition="text_exists",
+                text="ready",
+                **{argument: value},
+            )
+        )
+
+    assert desktop.calls == []
+
+
 def test_wait_for_timeout_reports_last_observed_state() -> None:
     desktop = FakeDesktop([_state(active_window_name="Explorer")])
     tools = _register_tools(desktop)


### PR DESCRIPTION
## Summary

- reject boolean, non-numeric, NaN, and infinite `WaitFor` timeout/interval values
- validate timing values before desktop capture or polling begins
- preserve the existing positive range checks for finite numeric values
- add regression coverage for invalid timing inputs

## Root cause

Python booleans are integers, so values such as `timeout=True` passed the existing numeric range
checks. NaN also compares false to both range boundaries, allowing a timeout that could never reach
its deadline normally.

## Compatibility

Existing finite integer and floating-point timing values remain compatible. Values that are not
valid finite durations now fail immediately with a clear `ValueError`.

## Testing

- changed-file `ruff check`: passed
- changed-file `ruff format --check`: passed
- focused WaitFor tests: `11 passed`
- full suite on this branch: `367 passed, 3 failed`
- full suite on unmodified `upstream/main`: `363 passed, 3 failed`
- the same three `tests/test_iserror_compliance.py` import failures occur on unmodified
  `upstream/main`

## Dependencies and scope

None. This branch is based directly on current `main`. It does not add new wait conditions or depend
on exact window control.
