### PR TITLE
fix(tests): repair broken isError-compliance regression test

### DIFF
--- a/tests/test_iserror_compliance.py
+++ b/tests/test_iserror_compliance.py
@@ -9,54 +9,79 @@ with `isError=false`. The fix replaces each such return with a bare
 Reference: https://composio.dev/blog/mcp-security-vulnerabilities (Dayna
 Blackwell MCP security audit, June 2026).
 """
+
+import asyncio
 import pytest
+
+try:
+    from fastmcp import FastMCP
+except ImportError:
+    FastMCP = None
 
 try:
     from fastmcp.exceptions import ToolError
 except ImportError:  # fastmcp not on the test platform
     ToolError = None  # type: ignore[misc,assignment]
 
-
 pytestmark = pytest.mark.skipif(
-    ToolError is None, reason="fastmcp not installed; test is non-Windows or fastmcp missing"
+    FastMCP is None or ToolError is None,
+    reason="fastmcp not installed; test is non-Windows or fastmcp missing",
 )
 
 
-def test_shell_tool_error_is_error_true(monkeypatch):
+@pytest.fixture(scope="module")
+def mcp():
+    _mcp = FastMCP(name="windows-mcp")
+    return _mcp
+
+
+def test_shell_tool_error_is_error_true(monkeypatch, mcp):
     """Shell tool failure must surface as ToolError → isError=true on wire."""
-    from windows_mcp.tools.shell import powershell_tool
+    from windows_mcp.tools.shell import register as shell_tool_reg
     from windows_mcp.powershell import PowerShellExecutor
 
-    def _raise(cmd, timeout):  # noqa: ARG001
-        raise RuntimeError("command rejected")
+    shell_tool_reg(mcp, get_desktop=lambda: None, get_analytics=lambda: None)
+    error_msg = "command rejected"
+
+    def _raise(*args, **kwargs):  # noqa: ARG001
+        raise RuntimeError(error_msg)
 
     monkeypatch.setattr(PowerShellExecutor, "execute_command", _raise)
     with pytest.raises(ToolError) as exc_info:
-        powershell_tool(command="bad-cmd")
-    assert "Error" in str(exc_info.value)
+        asyncio.run(mcp.call_tool("PowerShell", {"command": "bad-cmd"}))
+    assert error_msg in str(exc_info.value)
 
 
-def test_clipboard_tool_error_is_error_true(monkeypatch):
+def test_clipboard_tool_error_is_error_true(monkeypatch, mcp):
     """Clipboard tool failure must surface as ToolError."""
-    from windows_mcp.tools.clipboard import clipboard_tool
-    from windows_mcp.clipboard import ClipboardManager
+    from windows_mcp.tools.clipboard import register as clipboard_tool_reg
+    import win32clipboard
 
-    def _raise():
-        raise RuntimeError("clipboard locked")
+    clipboard_tool_reg(mcp, get_desktop=lambda: None, get_analytics=lambda: None)
+    error_msg = "clipboard locked"
 
-    monkeypatch.setattr(ClipboardManager, "copy", _raise)
-    with pytest.raises(ToolError):
-        clipboard_tool(mode="set", text="x")
+    def _raise(*args, **kwargs):
+        raise RuntimeError(error_msg)
+
+    monkeypatch.setattr(win32clipboard, "SetClipboardText", _raise)
+    with pytest.raises(ToolError) as exc_info:
+        asyncio.run(mcp.call_tool("Clipboard", {"mode": "set", "text": "x"}))
+    assert error_msg in str(exc_info.value)
 
 
-def test_registry_tool_error_is_error_true(monkeypatch):
+def test_registry_tool_error_is_error_true(monkeypatch, mcp):
     """Registry tool failure must surface as ToolError."""
-    from windows_mcp.tools.registry import registry_tool
-    from windows_mcp.registry import RegistryManager
+    from windows_mcp.tools.registry import register as registry_tool_reg
+    from windows_mcp import registry
 
-    def _raise(key):  # noqa: ARG001
-        raise PermissionError("access denied")
+    registry_tool_reg(mcp, get_desktop=lambda: None, get_analytics=lambda: None)
 
-    monkeypatch.setattr(RegistryManager, "read_value", _raise)
-    with pytest.raises(ToolError):
-        registry_tool(mode="get", name="HKLM\\X")
+    error_msg = "access denied"
+
+    def _raise(*args, **kwargs):  # noqa: ARG001
+        raise PermissionError(error_msg)
+
+    monkeypatch.setattr(registry, "get_value", _raise)
+    with pytest.raises(ToolError) as exc_info:
+        asyncio.run(mcp.call_tool("Registry", {"mode": "get", "path": "HKLM\\X", "name": "Nope"}))
+    assert error_msg in str(exc_info.value)


### PR DESCRIPTION
- `tests/test_iserror_compliance.py` (added in #300) referenced APIs that never existed in this codebase — top-level `powershell_tool`/`clipboard_tool`/`registry_tool` imports, plus `ClipboardManager` and `RegistryManager` classes. As a result the test file failed on import and never actually ran/verified anything.
- Rewrote the tests against the real `register(mcp, *, get_desktop, get_analytics)` pattern used by every tool module: register each tool onto a `FastMCP` instance and invoke it via `mcp.call_tool(...)`, matching how `__main__.py` wires tools up.
- Monkeypatches now target the actual functions the tool code calls (`registry.get_value`, `win32clipboard.SetClipboardText`, `PowerShellExecutor.execute_command`), and assertions check for the specific injected error message rather than a generic `"Error"` substring.

Maybe we should add a GitHub Action that runs this test suite on every PR, so broken/unverified tests like this one can't slip in again.
