### PR TITLE
Add unit test workflow for pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Unit tests (Python 3.13)
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install uv and Python
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --frozen --extra dev
+
+      - name: Run unit tests
+        run: uv run --frozen --extra dev pytest


### PR DESCRIPTION
PR #341  fixed problematic test cases introduced by PR #300. To prevent future PRs from introducing invalid or unreliable AI-generated tests, unit tests should run automatically before changes are merged.

- Run unit tests on pushes to main
- Run unit tests on PRs targeting main