### PR TITLE
docs: add mcpindex screened badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![mcpindex](https://mcpindex.ai/api/v1/badge/io-github-cursortouch-windows-mcp)](https://mcpindex.ai/server/io-github-cursortouch-windows-mcp)
+
 <div align="center">
   <h1>🪟 Windows-MCP</h1>
 


### PR DESCRIPTION
Hey, Windows-MCP's registered server came back clean on mcpindex's description-level screen (injection/manipulation check on the tool description). Added the badge to your README in case it's useful. Advisory only, not a security cert. Feel free to close if not.