### PR TITLE
Bound Snapshot/WaitFor tree capture size to prevent hangs and oversized output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ The codebase follows a layered service architecture under `src/windows_mcp/`:
 |---|---|---|
 | `WINDOWS_MCP_SCREENSHOT_SCALE` | `1.0` | Scale factor for screenshots (range `0.1`–`1.0`). Lower on 1440p/4K to stay under Claude Desktop's 1 MB limit. Resolved in `tools/_snapshot_helpers.py`. |
 | `WINDOWS_MCP_SCREENSHOT_BACKEND` | `auto` | Screenshot backend: `auto`, `dxcam`, `mss`, `pillow`. Resolved in `desktop/screenshot.py`. |
+| `WINDOWS_MCP_MAX_TREE_ELEMENTS` | `500` | Max UI elements a single Snapshot/WaitFor tree capture may collect before it stops descending and returns a truncated tree (with a note in the output). Bounds both traversal time and response size on huge flat lists/grids (e.g. an unfiltered inventory view with thousands of rows). Resolved in `tree/budget.py`. |
 | `WINDOWS_MCP_PROFILE_SNAPSHOT` | _(off)_ | Set to `1`/`true`/`yes`/`on` to log per-stage timing for Screenshot/Snapshot. Checked in `tools/_snapshot_helpers.py` and `desktop/service.py`. |
 | `ANONYMIZED_TELEMETRY` | `true` | Set to `false` to disable PostHog telemetry. Checked in `__main__.py` and `analytics.py`. |
 | `POSTHOG_API_KEY` | Project default | Override the PostHog project write key used for anonymous telemetry. Set to an empty string to skip PostHog client initialization. Checked in `analytics.py`. |

--- a/src/windows_mcp/desktop/service.py
+++ b/src/windows_mcp/desktop/service.py
@@ -1414,4 +1414,6 @@ class Desktop:
             dom_informative_nodes=tree_state.dom_informative_nodes if filtered_dom_node else [],
             capture_sec=tree_state.capture_sec,
             semantic_tree_root=filtered_semantic_root,
+            truncated=tree_state.truncated,
+            element_limit=tree_state.element_limit,
         )

--- a/src/windows_mcp/tree/budget.py
+++ b/src/windows_mcp/tree/budget.py
@@ -20,7 +20,15 @@ DEFAULT_MAX_TREE_ELEMENTS = 500
 
 
 def resolve_max_tree_elements(env: "os._Environ[str] | dict[str, str] | None" = None) -> int:
-    """Read WINDOWS_MCP_MAX_TREE_ELEMENTS, falling back to the default on any invalid value."""
+    """Read the tree-capture element limit from the environment.
+
+    Args:
+        env: Mapping to read from. Defaults to ``os.environ``.
+
+    Returns:
+        The configured limit, or ``DEFAULT_MAX_TREE_ELEMENTS`` if the
+        variable is unset, blank, non-numeric, or not a positive integer.
+    """
     source = os.environ if env is None else env
     raw = source.get("WINDOWS_MCP_MAX_TREE_ELEMENTS", "")
     if not raw.strip():
@@ -47,7 +55,7 @@ def resolve_max_tree_elements(env: "os._Environ[str] | dict[str, str] | None" = 
 class TreeElementBudget:
     """Tracks how many output-affecting elements a tree traversal has captured."""
 
-    def __init__(self, limit: int = DEFAULT_MAX_TREE_ELEMENTS):
+    def __init__(self, limit: int = DEFAULT_MAX_TREE_ELEMENTS) -> None:
         self.limit = max(1, limit)
         self.count = 0
         self.truncated = False
@@ -65,10 +73,16 @@ class TreeElementBudget:
 
         Returns False (and marks the budget truncated) once the limit is
         reached; the caller should then stop appending/recursing further.
+        `count` is hard-capped at `limit` — a single over-large `amount`
+        cannot push it past the configured budget.
         """
         if amount <= 0:
             return not self.exhausted
         if self.exhausted:
+            self.truncated = True
+            return False
+        if amount > self.remaining:
+            self.count = self.limit
             self.truncated = True
             return False
         self.count += amount

--- a/src/windows_mcp/tree/budget.py
+++ b/src/windows_mcp/tree/budget.py
@@ -1,0 +1,77 @@
+"""Bounds how many UI elements a single tree capture may collect.
+
+Some applications expose enormous flat lists/grids through UI Automation
+(e.g. an unfiltered inventory grid with thousands of rows). Walking and
+serializing every row can stall the target application for minutes and can
+produce a response too large for the calling client to handle. TreeElementBudget
+gives Tree.get_state a cheap, dependency-free way to stop early once a
+configurable element count is reached, while still returning a partial —
+clearly marked as truncated — result instead of hanging or failing outright.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_TREE_ELEMENTS = 500
+
+
+def resolve_max_tree_elements(env: "os._Environ[str] | dict[str, str] | None" = None) -> int:
+    """Read WINDOWS_MCP_MAX_TREE_ELEMENTS, falling back to the default on any invalid value."""
+    source = os.environ if env is None else env
+    raw = source.get("WINDOWS_MCP_MAX_TREE_ELEMENTS", "")
+    if not raw.strip():
+        return DEFAULT_MAX_TREE_ELEMENTS
+    try:
+        parsed = int(raw.strip())
+    except ValueError:
+        logger.warning(
+            "Invalid WINDOWS_MCP_MAX_TREE_ELEMENTS value %r, using default %d",
+            raw,
+            DEFAULT_MAX_TREE_ELEMENTS,
+        )
+        return DEFAULT_MAX_TREE_ELEMENTS
+    if parsed < 1:
+        logger.warning(
+            "WINDOWS_MCP_MAX_TREE_ELEMENTS %r must be >= 1, using default %d",
+            parsed,
+            DEFAULT_MAX_TREE_ELEMENTS,
+        )
+        return DEFAULT_MAX_TREE_ELEMENTS
+    return parsed
+
+
+class TreeElementBudget:
+    """Tracks how many output-affecting elements a tree traversal has captured."""
+
+    def __init__(self, limit: int = DEFAULT_MAX_TREE_ELEMENTS):
+        self.limit = max(1, limit)
+        self.count = 0
+        self.truncated = False
+
+    @property
+    def exhausted(self) -> bool:
+        return self.count >= self.limit
+
+    @property
+    def remaining(self) -> int:
+        return max(0, self.limit - self.count)
+
+    def try_consume(self, amount: int = 1) -> bool:
+        """Register `amount` newly captured elements.
+
+        Returns False (and marks the budget truncated) once the limit is
+        reached; the caller should then stop appending/recursing further.
+        """
+        if amount <= 0:
+            return not self.exhausted
+        if self.exhausted:
+            self.truncated = True
+            return False
+        self.count += amount
+        if self.exhausted:
+            self.truncated = True
+        return True

--- a/src/windows_mcp/tree/service.py
+++ b/src/windows_mcp/tree/service.py
@@ -650,6 +650,7 @@ class Tree:
                          if is_text:
                              if is_browser and is_dom:
                                  name = node.CachedName
+                                 self.element_budget.try_consume()
                                  dom_informative_nodes.append(TextElementNode(
                                      text=name.strip(),
                                  ))

--- a/src/windows_mcp/tree/service.py
+++ b/src/windows_mcp/tree/service.py
@@ -5,6 +5,7 @@ from _ctypes import COMError
 from windows_mcp.tree.config import INTERACTIVE_CONTROL_TYPE_NAMES, DOCUMENT_CONTROL_TYPE_NAMES, INFORMATIVE_CONTROL_TYPE_NAMES, DEFAULT_ACTIONS, INTERACTIVE_ROLES, THREAD_MAX_RETRIES, STRUCTURAL_CONTROL_TYPE_NAMES
 from windows_mcp.tree.views import TreeElementNode, ScrollElementNode, TextElementNode, Center, BoundingBox, TreeState, SemanticNode, _prune_structural, _reverse_children_order
 from windows_mcp.tree.cache_utils import CacheRequestFactory, CachedControlHelper
+from windows_mcp.tree.budget import TreeElementBudget, resolve_max_tree_elements
 from windows_mcp.tree.utils import random_point_within_bounding_box
 from windows_mcp.tree import ia2 as ia2_traversal
 from typing import TYPE_CHECKING,Optional,Any
@@ -51,6 +52,7 @@ class Tree:
         self.dom_is_ia2:bool=False
         self.screen_box=desktop.get_screen_box()
         self.tree_state=None
+        self.element_budget=TreeElementBudget(resolve_max_tree_elements())
 
 
     def get_state(self,active_window_handle:int|None,other_windows_handles:list[int],use_dom:bool=False)->TreeState:
@@ -58,6 +60,9 @@ class Tree:
         self.dom = None
         self.dom_bounding_box = None
         self.dom_is_ia2 = False
+        # Fresh budget per capture — huge lists/grids (e.g. thousands of rows) must not
+        # stall UI Automation or blow up the serialized response.
+        self.element_budget = TreeElementBudget(resolve_max_tree_elements())
         start_time = perf_counter()
         profile_enabled = _snapshot_profile_enabled()
 
@@ -129,9 +134,16 @@ class Tree:
         if not status:
             logger.warning(f"[Tree] {len(failed_handles)} window(s) failed to capture — UI services may be loading")
         end_time = perf_counter()
+        if self.element_budget.truncated:
+            logger.warning(
+                "[Tree] Capture truncated at %d elements (limit=%d) — some UI elements were "
+                "not visited. Set WINDOWS_MCP_MAX_TREE_ELEMENTS to raise the limit.",
+                self.element_budget.count,
+                self.element_budget.limit,
+            )
         if profile_enabled:
             logger.info(
-                "Snapshot tree profile: windows=%d active_window=%s interactive_nodes=%d scrollable_nodes=%d dom_nodes=%d failed_windows=%d total_ms=%.1f use_dom=%s",
+                "Snapshot tree profile: windows=%d active_window=%s interactive_nodes=%d scrollable_nodes=%d dom_nodes=%d failed_windows=%d total_ms=%.1f use_dom=%s truncated=%s",
                 len(windows_handles),
                 active_window_handle is not None,
                 len(interactive_nodes),
@@ -140,6 +152,7 @@ class Tree:
                 len(failed_handles),
                 (end_time - start_time) * 1000,
                 use_dom,
+                self.element_budget.truncated,
             )
         logger.info(f"[Tree] Tree State capture took {end_time - start_time:.2f} seconds")
         return TreeState(
@@ -151,6 +164,8 @@ class Tree:
             dom_informative_nodes=dom_informative_nodes,
             capture_sec=end_time - start_time,
             semantic_tree_root=desktop_root,
+            truncated=self.element_budget.truncated,
+            element_limit=self.element_budget.limit,
         )
 
     def get_window_wise_nodes(self,windows_handles:list[int],active_window_flag:bool,use_dom:bool=False) -> tuple[list[TreeElementNode],list[ScrollElementNode],list[TextElementNode],list[int],list[SemanticNode]]:
@@ -180,6 +195,13 @@ class Tree:
 
         retry_counts = {handle: 0 for handle in windows_handles}
         for handle, is_browser in task_inputs:
+            if self.element_budget.exhausted:
+                logger.debug(
+                    "[Tree] Element budget exhausted (%d/%d) — skipping remaining windows",
+                    self.element_budget.count,
+                    self.element_budget.limit,
+                )
+                break
             for attempt in range(THREAD_MAX_RETRIES + 1):
                 try:
                     result = self.get_nodes(handle, is_browser, wait_time=0.5 * (2 ** (attempt - 1)) if attempt > 0 else 0, use_dom=use_dom)
@@ -358,6 +380,7 @@ class Tree:
                             metadata['vertical_scroll_percent']=round(scroll_pattern.VerticalScrollPercent,2) if scroll_pattern.VerticallyScrollable else 0
 
                             sem_scroll_name = name.strip() or automation_id or localized_control_type.capitalize() or "''"
+                            self.element_budget.try_consume()
                             scrollable_nodes.append(ScrollElementNode(**{
                                 'name':sem_scroll_name,
                                 'control_type':localized_control_type.title(),
@@ -574,6 +597,7 @@ class Tree:
                                     'window_name':window_name,
                                     'metadata':metadata
                                 })
+                                self.element_budget.try_consume()
                                 dom_interactive_nodes.append(tree_node)
                                 self._dom_correction(node, dom_interactive_nodes, window_name)
                             else:
@@ -588,6 +612,7 @@ class Tree:
                                         'window_name':window_name,
                                         'metadata':metadata
                                     })
+                                    self.element_budget.try_consume()
                                     interactive_nodes.append(tree_node)
                                     if current_semantic_node is not None:
                                         current_semantic_node.add_child(SemanticNode(
@@ -652,6 +677,11 @@ class Tree:
 
             # Recursively traverse the tree the right to left for normal apps and for DOM traverse from left to right
             for child in (children if is_dom else reversed(children)):
+                if self.element_budget.exhausted:
+                    # Stop descending once the element budget is spent — this is what
+                    # bounds traversal time on huge flat lists/grids (thousands of rows),
+                    # not just the size of the appended node lists.
+                    break
                 try:
                     # Check if the child is a DOM element
                     if is_browser and child.CachedAutomationId=="RootWebArea":
@@ -773,8 +803,21 @@ class Tree:
                     )
                     ia2_ms = (perf_counter() - ia2_t0) * 1000
                     if ia2_result:
-                        dom_interactive_nodes.extend(ia2_result.interactive_nodes)
-                        dom_informative_nodes.extend(ia2_result.informative_nodes)
+                        # traverse_window() already walked the whole IAccessible tree before
+                        # returning, so this can't bound traversal time — but it still caps
+                        # how much of the result gets appended/serialized.
+                        remaining = self.element_budget.remaining
+                        capped_interactive = ia2_result.interactive_nodes[:remaining]
+                        remaining_after_interactive = max(0, remaining - len(capped_interactive))
+                        capped_informative = ia2_result.informative_nodes[:remaining_after_interactive]
+                        if (
+                            len(capped_interactive) < len(ia2_result.interactive_nodes)
+                            or len(capped_informative) < len(ia2_result.informative_nodes)
+                        ):
+                            self.element_budget.truncated = True
+                        self.element_budget.try_consume(len(capped_interactive) + len(capped_informative))
+                        dom_interactive_nodes.extend(capped_interactive)
+                        dom_informative_nodes.extend(capped_informative)
                         # Pin the bbox to the FIRST Firefox window walked (the active
                         # one — it's first in windows_handles). Subsequent windows
                         # contribute nodes but mustn't clobber the active window's bbox.

--- a/src/windows_mcp/tree/views.py
+++ b/src/windows_mcp/tree/views.py
@@ -78,6 +78,15 @@ def _render_tree(nodes: list, meta_fn) -> str:
     return "\n".join(lines).rstrip()
 
 
+def _truncation_note(element_limit: int) -> str:
+    return (
+        f"... [truncated: reached the {element_limit}-element capture limit — "
+        "some elements were not visited. Narrow the view (filter by window, scroll to "
+        "the area of interest, use_dom=True for a browser page) or raise "
+        "WINDOWS_MCP_MAX_TREE_ELEMENTS for a complete tree.]"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Semantic tree — full parent-child hierarchy (Option B)
 # ---------------------------------------------------------------------------
@@ -162,23 +171,34 @@ class TreeState:
     dom_informative_nodes: list["TextElementNode"] = field(default_factory=list)
     capture_sec: float = 0.0
     semantic_tree_root: "SemanticNode | None" = None
+    truncated: bool = False
+    element_limit: int = 0
 
     def semantic_tree_to_string(self) -> str:
         if not self.semantic_tree_root:
             return "No elements"
         lines: list[str] = []
         _render_semantic_node(self.semantic_tree_root, lines, "", is_last=True)
-        return "\n".join(lines)
+        text = "\n".join(lines)
+        if self.truncated:
+            text += "\n\n" + _truncation_note(self.element_limit)
+        return text
 
     def interactive_elements_to_string(self) -> str:
         if not self.interactive_nodes:
             return "No interactive elements"
-        return _render_tree(self.interactive_nodes, _node_meta_str)
+        text = _render_tree(self.interactive_nodes, _node_meta_str)
+        if self.truncated:
+            text += "\n\n" + _truncation_note(self.element_limit)
+        return text
 
     def scrollable_elements_to_string(self) -> str:
         if not self.scrollable_nodes:
             return "No scrollable elements"
-        return _render_tree(self.scrollable_nodes, _scroll_meta_str)
+        text = _render_tree(self.scrollable_nodes, _scroll_meta_str)
+        if self.truncated:
+            text += "\n\n" + _truncation_note(self.element_limit)
+        return text
 
 
 @dataclass

--- a/tests/test_tree_budget.py
+++ b/tests/test_tree_budget.py
@@ -35,8 +35,8 @@ class TestTreeElementBudget:
     def test_try_consume_batch_exceeding_remaining(self):
         budget = TreeElementBudget(limit=5)
         assert budget.try_consume(3) is True
-        assert budget.try_consume(10) is True
-        assert budget.count == 13
+        assert budget.try_consume(10) is False
+        assert budget.count == 5
         assert budget.truncated is True
 
     def test_try_consume_zero_amount_does_not_change_count(self):
@@ -52,6 +52,7 @@ class TestTreeElementBudget:
         budget = TreeElementBudget(limit=2)
         budget.try_consume(10)
         assert budget.remaining == 0
+        assert budget.count == 2
 
 
 class TestResolveMaxTreeElements:
@@ -59,7 +60,10 @@ class TestResolveMaxTreeElements:
         assert resolve_max_tree_elements({}) == DEFAULT_MAX_TREE_ELEMENTS
 
     def test_default_when_blank(self):
-        assert resolve_max_tree_elements({"WINDOWS_MCP_MAX_TREE_ELEMENTS": "  "}) == DEFAULT_MAX_TREE_ELEMENTS
+        assert (
+            resolve_max_tree_elements({"WINDOWS_MCP_MAX_TREE_ELEMENTS": "  "})
+            == DEFAULT_MAX_TREE_ELEMENTS
+        )
 
     def test_valid_override(self):
         assert resolve_max_tree_elements({"WINDOWS_MCP_MAX_TREE_ELEMENTS": "150"}) == 150

--- a/tests/test_tree_budget.py
+++ b/tests/test_tree_budget.py
@@ -1,0 +1,77 @@
+from windows_mcp.tree.budget import (
+    DEFAULT_MAX_TREE_ELEMENTS,
+    TreeElementBudget,
+    resolve_max_tree_elements,
+)
+
+
+class TestTreeElementBudget:
+    def test_starts_unexhausted(self):
+        budget = TreeElementBudget(limit=3)
+        assert budget.exhausted is False
+        assert budget.truncated is False
+        assert budget.remaining == 3
+
+    def test_try_consume_under_limit(self):
+        budget = TreeElementBudget(limit=3)
+        assert budget.try_consume() is True
+        assert budget.count == 1
+        assert budget.truncated is False
+
+    def test_try_consume_reaching_limit_marks_truncated(self):
+        budget = TreeElementBudget(limit=2)
+        assert budget.try_consume() is True
+        assert budget.try_consume() is True
+        assert budget.exhausted is True
+        assert budget.truncated is True
+
+    def test_try_consume_beyond_limit_returns_false(self):
+        budget = TreeElementBudget(limit=1)
+        assert budget.try_consume() is True
+        assert budget.try_consume() is False
+        assert budget.count == 1
+        assert budget.truncated is True
+
+    def test_try_consume_batch_exceeding_remaining(self):
+        budget = TreeElementBudget(limit=5)
+        assert budget.try_consume(3) is True
+        assert budget.try_consume(10) is True
+        assert budget.count == 13
+        assert budget.truncated is True
+
+    def test_try_consume_zero_amount_does_not_change_count(self):
+        budget = TreeElementBudget(limit=5)
+        assert budget.try_consume(0) is True
+        assert budget.count == 0
+
+    def test_limit_is_clamped_to_at_least_one(self):
+        budget = TreeElementBudget(limit=0)
+        assert budget.limit == 1
+
+    def test_remaining_never_negative(self):
+        budget = TreeElementBudget(limit=2)
+        budget.try_consume(10)
+        assert budget.remaining == 0
+
+
+class TestResolveMaxTreeElements:
+    def test_default_when_unset(self):
+        assert resolve_max_tree_elements({}) == DEFAULT_MAX_TREE_ELEMENTS
+
+    def test_default_when_blank(self):
+        assert resolve_max_tree_elements({"WINDOWS_MCP_MAX_TREE_ELEMENTS": "  "}) == DEFAULT_MAX_TREE_ELEMENTS
+
+    def test_valid_override(self):
+        assert resolve_max_tree_elements({"WINDOWS_MCP_MAX_TREE_ELEMENTS": "150"}) == 150
+
+    def test_invalid_value_falls_back_to_default(self):
+        assert (
+            resolve_max_tree_elements({"WINDOWS_MCP_MAX_TREE_ELEMENTS": "not-a-number"})
+            == DEFAULT_MAX_TREE_ELEMENTS
+        )
+
+    def test_zero_falls_back_to_default(self):
+        assert resolve_max_tree_elements({"WINDOWS_MCP_MAX_TREE_ELEMENTS": "0"}) == DEFAULT_MAX_TREE_ELEMENTS
+
+    def test_negative_falls_back_to_default(self):
+        assert resolve_max_tree_elements({"WINDOWS_MCP_MAX_TREE_ELEMENTS": "-5"}) == DEFAULT_MAX_TREE_ELEMENTS

--- a/tests/test_tree_service.py
+++ b/tests/test_tree_service.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 import pytest
 from windows_mcp.desktop.views import Size
+from windows_mcp.tree.budget import TreeElementBudget
 from windows_mcp.tree.service import Tree, _is_comtypes_variant_ord_typeerror
 from windows_mcp.tree.views import BoundingBox, SemanticNode
 from windows_mcp.uia import Rect
@@ -180,3 +181,134 @@ class TestTreeTraversal:
 
         assert interactive_nodes == []
         assert semantic_root.children == []
+
+
+def _make_button_child(name: str, left: int) -> MagicMock:
+    child = MagicMock()
+    child.CachedIsOffscreen = False
+    child.CachedControlTypeName = "ButtonControl"
+    child.CachedIsControlElement = True
+    child.CachedBoundingRectangle = Rect(left, 10, left + 40, 60)
+    child.CachedIsEnabled = True
+    child.CachedHasKeyboardFocus = False
+    child.CachedName = name
+    child.CachedLocalizedControlType = "button"
+    child.CachedAcceleratorKey = ""
+    child.CachedHelpText = ""
+    child.GetCachedPropertyValue.return_value = 43
+    return child
+
+
+def _make_pane_parent() -> MagicMock:
+    parent = MagicMock()
+    parent.CachedIsOffscreen = False
+    parent.CachedControlTypeName = "PaneControl"
+    parent.CachedIsControlElement = True
+    parent.CachedBoundingRectangle = Rect(0, 0, 500, 500)
+    parent.CachedIsEnabled = True
+    parent.CachedIsKeyboardFocusable = False
+    parent.CachedName = ""
+    # Disable the scrollable-container branch — irrelevant to this test and
+    # would otherwise call random_point_within_bounding_box on an unconfigured mock.
+    parent.GetCachedPattern.return_value = None
+    return parent
+
+
+class TestElementBudgetStopsTraversal:
+    """A huge flat list/grid (e.g. thousands of UIA rows) must not be walked in full —
+    see budget.py. These tests exercise the wiring in tree_traversal / get_window_wise_nodes.
+    """
+
+    def test_stops_appending_and_recursing_once_budget_exhausted(
+        self, tree_instance, monkeypatch
+    ):
+        parent = _make_pane_parent()
+        children = [_make_button_child(f"btn{i}", 10 * i) for i in range(5)]
+
+        def fake_get_children(node, cache_request):
+            return children if node is parent else []
+
+        monkeypatch.setattr(
+            "windows_mcp.tree.service.CachedControlHelper.get_cached_children",
+            fake_get_children,
+        )
+        monkeypatch.setattr("windows_mcp.tree.service.AccessibleRoleNames", {43: "PushButton"})
+
+        tree_instance.element_budget = TreeElementBudget(limit=3)
+
+        interactive_nodes = []
+        tree_instance.tree_traversal(
+            parent,
+            Rect(0, 0, 500, 500),
+            "Window",
+            False,
+            interactive_nodes,
+            [],
+            [],
+            [],
+        )
+
+        assert len(interactive_nodes) == 3
+        assert tree_instance.element_budget.truncated is True
+        assert tree_instance.element_budget.count == 3
+
+    def test_all_elements_captured_when_under_budget(self, tree_instance, monkeypatch):
+        parent = _make_pane_parent()
+        children = [_make_button_child(f"btn{i}", 10 * i) for i in range(5)]
+
+        def fake_get_children(node, cache_request):
+            return children if node is parent else []
+
+        monkeypatch.setattr(
+            "windows_mcp.tree.service.CachedControlHelper.get_cached_children",
+            fake_get_children,
+        )
+        monkeypatch.setattr("windows_mcp.tree.service.AccessibleRoleNames", {43: "PushButton"})
+
+        tree_instance.element_budget = TreeElementBudget(limit=10)
+
+        interactive_nodes = []
+        tree_instance.tree_traversal(
+            parent,
+            Rect(0, 0, 500, 500),
+            "Window",
+            False,
+            interactive_nodes,
+            [],
+            [],
+            [],
+        )
+
+        assert len(interactive_nodes) == 5
+        assert tree_instance.element_budget.truncated is False
+
+    def test_get_window_wise_nodes_skips_remaining_windows_once_exhausted(
+        self, tree_instance, monkeypatch
+    ):
+        tree_instance.element_budget = TreeElementBudget(limit=1)
+        tree_instance.element_budget.try_consume(1)
+        assert tree_instance.element_budget.exhausted is True
+
+        # `tree_instance.desktop` is a weakref.proxy to a mock that only lives for the
+        # duration of the fixture — swap in a plain, still-alive mock before touching it.
+        live_desktop = MagicMock()
+        live_desktop.is_window_browser.return_value = False
+        tree_instance.desktop = live_desktop
+
+        calls = []
+        monkeypatch.setattr(
+            "windows_mcp.tree.service.ControlFromHandle",
+            lambda handle: MagicMock(ClassName="SomeWindow", Name="Some Window"),
+        )
+
+        def fake_get_nodes(self, handle, is_browser=False, wait_time=0, use_dom=False):
+            calls.append(handle)
+            return ([], [], [], None)
+
+        monkeypatch.setattr(Tree, "get_nodes", fake_get_nodes)
+
+        tree_instance.get_window_wise_nodes(
+            windows_handles=[111, 222, 333], active_window_flag=False
+        )
+
+        assert calls == []

--- a/tests/test_tree_service.py
+++ b/tests/test_tree_service.py
@@ -199,6 +199,18 @@ def _make_button_child(name: str, left: int) -> MagicMock:
     return child
 
 
+def _make_text_child(text: str, left: int) -> MagicMock:
+    child = MagicMock()
+    child.CachedIsOffscreen = False
+    child.CachedControlTypeName = "TextControl"
+    child.CachedIsControlElement = True
+    child.CachedBoundingRectangle = Rect(left, 10, left + 40, 60)
+    child.CachedIsEnabled = True
+    child.CachedIsKeyboardFocusable = False
+    child.CachedName = text
+    return child
+
+
 def _make_pane_parent() -> MagicMock:
     parent = MagicMock()
     parent.CachedIsOffscreen = False
@@ -281,6 +293,40 @@ class TestElementBudgetStopsTraversal:
 
         assert len(interactive_nodes) == 5
         assert tree_instance.element_budget.truncated is False
+
+    def test_dom_informative_text_nodes_consume_budget(self, tree_instance, monkeypatch):
+        # Text-heavy DOM pages must not bypass the budget just because the nodes
+        # are informative rather than interactive — see PR review finding on
+        # unbudgeted `dom_informative_nodes.append(TextElementNode(...))`.
+        parent = _make_pane_parent()
+        children = [_make_text_child(f"paragraph {i}", 10 * i) for i in range(5)]
+
+        def fake_get_children(node, cache_request):
+            return children if node is parent else []
+
+        monkeypatch.setattr(
+            "windows_mcp.tree.service.CachedControlHelper.get_cached_children",
+            fake_get_children,
+        )
+
+        tree_instance.element_budget = TreeElementBudget(limit=3)
+
+        dom_informative_nodes = []
+        tree_instance.tree_traversal(
+            parent,
+            Rect(0, 0, 500, 500),
+            "Window",
+            True,
+            [],
+            [],
+            [],
+            dom_informative_nodes,
+            is_dom=True,
+        )
+
+        assert len(dom_informative_nodes) == 3
+        assert tree_instance.element_budget.truncated is True
+        assert tree_instance.element_budget.count == 3
 
     def test_get_window_wise_nodes_skips_remaining_windows_once_exhausted(
         self, tree_instance, monkeypatch

--- a/tests/test_tree_views.py
+++ b/tests/test_tree_views.py
@@ -98,7 +98,7 @@ class TestTreeState:
         root.add_child(window)
         ts = TreeState(semantic_tree_root=root, truncated=True, element_limit=500)
         result = ts.semantic_tree_to_string()
-        assert 'window "Notepad"' in result
+        assert "window \"Notepad\"" in result
         assert "500-element capture limit" in result
 
     def test_semantic_tree_not_truncated_omits_note(self) -> None:

--- a/tests/test_tree_views.py
+++ b/tests/test_tree_views.py
@@ -4,6 +4,7 @@ from windows_mcp.tree.views import (
     BoundingBox,
     Center,
     ScrollElementNode,
+    SemanticNode,
     TreeElementNode,
     TreeState,
 )
@@ -63,6 +64,48 @@ class TestTreeState:
     def test_interactive_elements_to_string_empty(self):
         ts = TreeState()
         assert ts.interactive_elements_to_string() == "No interactive elements"
+
+    def test_truncated_appends_note_to_interactive_elements(
+        self, sample_tree_element_node: TreeElementNode
+    ) -> None:
+        ts = TreeState(
+            interactive_nodes=[sample_tree_element_node], truncated=True, element_limit=500
+        )
+        result = ts.interactive_elements_to_string()
+        assert "500-element capture limit" in result
+        assert "WINDOWS_MCP_MAX_TREE_ELEMENTS" in result
+
+    def test_truncated_appends_note_to_scrollable_elements(
+        self, sample_scroll_element_node: ScrollElementNode
+    ) -> None:
+        ts = TreeState(scrollable_nodes=[sample_scroll_element_node], truncated=True, element_limit=42)
+        result = ts.scrollable_elements_to_string()
+        assert "42-element capture limit" in result
+
+    def test_not_truncated_omits_note(self, sample_tree_element_node: TreeElementNode) -> None:
+        ts = TreeState(interactive_nodes=[sample_tree_element_node], truncated=False)
+        result = ts.interactive_elements_to_string()
+        assert "truncated" not in result
+
+    def test_truncated_with_no_elements_still_shows_note(self) -> None:
+        ts = TreeState(truncated=True, element_limit=10)
+        result = ts.interactive_elements_to_string()
+        assert result == "No interactive elements"
+
+    def test_truncated_appends_note_to_semantic_tree(self) -> None:
+        root = SemanticNode(control_type="Desktop", element_type="desktop", name="Desktop")
+        window = SemanticNode(control_type="Window", element_type="window", name="Notepad")
+        root.add_child(window)
+        ts = TreeState(semantic_tree_root=root, truncated=True, element_limit=500)
+        result = ts.semantic_tree_to_string()
+        assert 'window "Notepad"' in result
+        assert "500-element capture limit" in result
+
+    def test_semantic_tree_not_truncated_omits_note(self) -> None:
+        root = SemanticNode(control_type="Desktop", element_type="desktop", name="Desktop")
+        ts = TreeState(semantic_tree_root=root, truncated=False)
+        result = ts.semantic_tree_to_string()
+        assert "truncated" not in result
 
     def test_interactive_elements_to_string_with_elements(
         self, sample_tree_element_node: TreeElementNode


### PR DESCRIPTION
## Problem

`Tree.tree_traversal` (`tree/service.py`) walks the full UI Automation subtree of every visible window with no cap on element count. Against a window that exposes a large flat list or grid (e.g. an unfiltered inventory/table view with thousands of rows), this can:

- stall UI Automation on the target application for minutes while the traversal fetches cached properties for every row, and
- produce a serialized response far too large for the calling MCP client to accept, even once the capture itself finishes.

Observed in practice against a ~9,860-row list view: one `Snapshot` call blocked the target app for 30+ minutes; another returned a 54k+ character response that the calling client rejected outright.

`WaitFor` polls the same `Tree.get_state` capture path (via `_iter_nodes`/`_iter_text_sources`), so it's affected identically.

## Fix

- New `tree/budget.py`: a small, dependency-free `TreeElementBudget` that tracks how many output-affecting elements a capture has collected, plus `resolve_max_tree_elements()` reading `WINDOWS_MCP_MAX_TREE_ELEMENTS` (default `500`).
- `Tree.get_state` resets a fresh budget per capture.
- `tree_traversal` checks the budget before recursing into each child and **stops descending** once it's exhausted — this is what bounds traversal time, not just the size of the appended lists.
- `get_window_wise_nodes` skips any remaining windows once the budget is spent.
- The IA2/Firefox fallback path (which returns its full result in one call, so it can't be bounded incrementally) truncates its already-collected result to the remaining budget.
- `TreeState` gains `truncated: bool` and `element_limit: int`; `semantic_tree_to_string()`, `interactive_elements_to_string()`, and `scrollable_elements_to_string()` append a clear note when the capture was cut short, so truncation is visible in the tool response instead of silent.
- `desktop/service.py`'s `_filter_tree_state_to_region` (used when a `display` region is requested) passes the new fields through so the flag survives region filtering.

No tool-facing API change — existing `Snapshot`/`WaitFor` calls just get a bounded, clearly-marked partial result instead of a hang or an oversized response. Raising the limit (or disabling it in practice by setting a very high value) is available via env var for anyone who wants the old unbounded behavior.

## Testing

- `tests/test_tree_budget.py` (new): unit tests for `TreeElementBudget`/`resolve_max_tree_elements` — pure Python, no UIA dependency.
- `tests/test_tree_views.py`: new cases for the truncation note on all three renderers (present when `truncated=True`, absent otherwise, omitted when the specific node list is empty).
- `tests/test_tree_service.py`: new cases exercising the wiring — `tree_traversal` stops appending/recursing once the budget is exhausted and leaves it untouched when under budget; `get_window_wise_nodes` skips remaining windows once exhausted.
- Ran locally: `tests/test_tree_budget.py` and `tests/test_tree_views.py` pass (36 tests) and `ruff check` is clean on all touched files. I don't have a Windows box handy, so I could not run `tests/test_tree_service.py` locally (it imports `comtypes`/`pywin32`, matching this repo's CI which runs on `windows-latest`) — those new tests follow the exact `MagicMock`-based pattern already used in that file and I traced the logic by hand against the traversal code, but please let the CI run confirm.

## Config

Documented the new `WINDOWS_MCP_MAX_TREE_ELEMENTS` env var in `CLAUDE.md`'s environment variable table, consistent with the existing entries there.