### PR TITLE
fix: report missing startup dependencies instead of exiting with a bare traceback

### DIFF
--- a/src/windows_mcp/__main__.py
+++ b/src/windows_mcp/__main__.py
@@ -22,7 +22,7 @@ from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
 from textwrap import dedent
 from enum import Enum
-from typing import Any
+from typing import Any, NoReturn
 import logging
 import asyncio
 import shlex
@@ -178,6 +178,27 @@ def _watchdog_enabled() -> bool:
     return value.strip().lower() not in {"off", "0", "false", "no", "disabled"}
 
 
+def _exit_missing_dependency(exc: ModuleNotFoundError) -> NoReturn:
+    """Report a missing runtime dependency on stderr and exit non-zero.
+
+    A partially populated venv -- an interrupted `uv sync`, or one invalidated
+    by an interpreter change -- leaves `windows_mcp` importable next to missing
+    third-party packages. Without this guard the traceback is the only output,
+    and MCP hosts do not surface it: Claude Desktop reports "Server
+    disconnected" alone, so neither the failing module nor the remedy reaches
+    the user. Written to stderr because stdout carries the stdio protocol
+    stream. `uv sync` repairs any declared dependency, so the message points
+    there rather than mapping the import name back to its distribution.
+    """
+    logger.debug("Startup import failed", exc_info=exc)
+    click.echo(
+        f"windows-mcp: cannot start -- {exc}. The environment looks partially "
+        f"installed; run `uv sync` in the extension directory, then restart the client.",
+        err=True,
+    )
+    sys.exit(1)
+
+
 def _build_mcp() -> FastMCP:
     """Create the MCP server instance."""
     global _mcp
@@ -185,9 +206,12 @@ def _build_mcp() -> FastMCP:
     if _mcp is not None:
         return _mcp
 
-    from windows_mcp.infrastructure import PostHogAnalytics
-    from windows_mcp.desktop.service import Desktop
-    from windows_mcp.tools import register_all
+    try:
+        from windows_mcp.infrastructure import PostHogAnalytics
+        from windows_mcp.desktop.service import Desktop
+        from windows_mcp.tools import register_all
+    except ModuleNotFoundError as exc:
+        _exit_missing_dependency(exc)
 
     @asynccontextmanager
     async def lifespan(app: FastMCP):

--- a/tests/test_startup_dependency_guard.py
+++ b/tests/test_startup_dependency_guard.py
@@ -1,0 +1,17 @@
+import pytest
+
+from windows_mcp import __main__ as wm
+
+
+def test_missing_dependency_exits_nonzero_with_actionable_stderr(capsys):
+    exc = ModuleNotFoundError("No module named 'win32com.shell'", name="win32com.shell")
+
+    with pytest.raises(SystemExit) as excinfo:
+        wm._exit_missing_dependency(exc)
+
+    assert excinfo.value.code == 1
+    captured = capsys.readouterr()
+    assert "win32com.shell" in captured.err
+    assert "uv sync" in captured.err
+    # stdout carries the MCP stdio protocol stream and must stay clean.
+    assert captured.out == ""


### PR DESCRIPTION
Refs #345.

## Problem

`_build_mcp()` imports the desktop service with no exception handling. On a partially populated venv a single missing dependency produces an unhandled traceback and process exit. MCP hosts do not surface that traceback — Claude Desktop shows only "Server disconnected" — so the user gets no indication of which package is missing or how to recover. The state does not self-heal: the venv looks built, so it is never rebuilt.

Two independent triggers are known to produce the partially populated venv (see #345): an interpreter change invalidating the venv, and a cold build truncated by the client's initialize handshake timeout. This PR addresses neither trigger. It makes the resulting failure legible.

## Change

Wrap the three startup imports in `_build_mcp()` in `try/except ModuleNotFoundError`, and add `_exit_missing_dependency()`, which logs the exception at debug level, writes one line to stderr naming the failing module and pointing at `uv sync`, and exits 1. stderr rather than stdout, because stdout carries the stdio protocol stream.

New test asserts exit code 1, that stderr names the failing module and the remedy, and that stdout stays empty.

No refactors, no new dependencies, no packaging changes. `click`, `sys` and `logger` were already in scope; `NoReturn` keeps the fall-through after `except` statically sound.

## Verification

Reproduced the real failure by renaming `win32comext/` out of a synced venv, which yields the exact error from #345 at `desktop/utils.py:7`. Before the change the process exits on an unhandled traceback. After:

```
$ windows-mcp serve --transport stdio
exit code: 1
stdout:    (empty)
stderr:    windows-mcp: cannot start -- No module named 'win32com.shell'. The environment
           looks partially installed; run `uv sync` in the extension directory, then
           restart the client.
```

Full suite: 411 passed. `ruff check`: clean.

## Known tradeoff in the catch

`except ModuleNotFoundError` around those three imports will also catch a `ModuleNotFoundError` raised *inside* `windows_mcp.tools` or `windows_mcp.infrastructure` — an internal import typo, for instance. In that case the message ("the environment looks partially installed; run `uv sync`") is wrong and points at a dead end.

This is deliberate. CI runs the suite on `windows-latest` and imports both packages, so an internal import error fails before release, whereas the partial-venv case only ever appears on user machines. Narrowing the catch by inspecting `exc.name` against an allowlist of declared distributions is the scope creep this PR is trying to avoid. Happy to add that if you would rather have it.

## Considered and not included

Importing `shell` from `win32comext.shell` instead of `win32com.shell` in `desktop/utils.py`. The `__path__` splice in `win32com/__init__.py` exists so that `win32com.shell` is the supported public name, and when pywin32 is genuinely absent the change only alters which module name appears in the error. Left alone deliberately.

The pywin32 post-install step (`pywin32_postinstall.py -install`) is not run by uv or pip, but does not appear to be required here — CI runs `uv sync --frozen` on `windows-latest` with no post-install and imports `desktop.utils` via the test suite successfully. Packaging left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
