### PR TITLE
Fix corrupted comtypes.gen cache from concurrent generation

### DIFF
--- a/src/windows_mcp/tree/ia2.py
+++ b/src/windows_mcp/tree/ia2.py
@@ -46,7 +46,9 @@ def _iaccessible():
         import comtypes.client
         from comtypes import GUID
 
-        comtypes.client.GetModule("oleacc.dll")
+        from windows_mcp.uia.comtypes_cache import safe_get_module
+
+        safe_get_module("oleacc.dll", required_attr="IAccessible")
         from comtypes.gen.Accessibility import IAccessible  # type: ignore
 
         _IAccessible = IAccessible

--- a/src/windows_mcp/uia/comtypes_cache.py
+++ b/src/windows_mcp/uia/comtypes_cache.py
@@ -12,35 +12,65 @@ every subsequent startup fails with ImportError/AttributeError.
 2. automatic cache clearing + regeneration when corruption is detected.
 """
 
+import errno
 import hashlib
 import msvcrt
 import os
 import shutil
 import sys
 import tempfile
+import time
 from contextlib import contextmanager
+from types import ModuleType
+from typing import Iterator, Optional
 
 import comtypes.client
 
-_LOCK_PATH = os.path.join(
+_LOCK_PATH: str = os.path.join(
     tempfile.gettempdir(),
     "comtypes-gen-%s.lock" % hashlib.md5(sys.prefix.encode("utf-8")).hexdigest(),
 )
 
+# msvcrt.locking(LK_LOCK) retries for ~10s and then raises OSError with one of
+# these errno values while the lock is still held by another process.
+_CONTENTION_ERRNOS: tuple[int, ...] = (errno.EACCES, errno.EDEADLK)
+
+_LOCK_TIMEOUT_SECONDS: float = 120.0
+
 
 @contextmanager
-def comtypes_cache_lock():
-    """Cross-process lock serializing comtypes.gen cache generation."""
+def comtypes_cache_lock(timeout: float = _LOCK_TIMEOUT_SECONDS) -> Iterator[None]:
+    """Cross-process lock serializing comtypes.gen cache generation.
+
+    Args:
+        timeout: Maximum number of seconds to wait for the lock before
+            giving up.
+
+    Yields:
+        None. The lock is held for the duration of the ``with`` block.
+
+    Raises:
+        TimeoutError: If the lock could not be acquired within ``timeout``
+            seconds.
+        OSError: For locking failures that are not lock contention (e.g. an
+            invalid handle); re-raised immediately.
+    """
     fd = os.open(_LOCK_PATH, os.O_CREAT | os.O_RDWR)
+    deadline = time.monotonic() + timeout
     try:
         while True:
             try:
-                # Blocks and retries for ~10s, then raises OSError; loop
-                # until the other process releases the lock.
+                # Blocks and retries for ~10s per call, then raises OSError.
                 msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
                 break
-            except OSError:
-                continue
+            except OSError as ex:
+                if ex.errno not in _CONTENTION_ERRNOS:
+                    raise
+                if time.monotonic() >= deadline:
+                    raise TimeoutError(
+                        "timed out after %.0fs waiting for comtypes cache "
+                        "lock %r" % (timeout, _LOCK_PATH)
+                    ) from ex
         yield
     finally:
         try:
@@ -51,14 +81,20 @@ def comtypes_cache_lock():
 
 
 def _clear_gen_cache() -> None:
-    """Delete generated modules so comtypes can regenerate them cleanly."""
+    """Best-effort removal of generated modules so comtypes can regenerate.
+
+    Never raises: this runs on the corruption-recovery path, where a failure
+    to clear should fall through to the retry rather than mask the original
+    error with a new one.
+    """
     try:
         import comtypes.gen as gen
 
-        gen_dir = os.path.dirname(gen.__file__)
+        gen_dir = os.path.dirname(gen.__file__ or "")
+        entries = os.listdir(gen_dir)
     except Exception:
         return
-    for name in os.listdir(gen_dir):
+    for name in entries:
         if name == "__init__.py":
             continue
         path = os.path.join(gen_dir, name)
@@ -74,12 +110,24 @@ def _clear_gen_cache() -> None:
             del sys.modules[mod_name]
 
 
-def safe_get_module(tlib, required_attr=None):
+def safe_get_module(tlib: str, required_attr: Optional[str] = None) -> ModuleType:
     """``comtypes.client.GetModule`` with locking and corrupt-cache recovery.
 
-    ``required_attr`` optionally names an attribute the generated module must
-    expose; a partially generated cache that imports but lacks it is treated
-    as corrupted and regenerated as well.
+    Args:
+        tlib: Type library to generate a wrapper for, e.g. a DLL name such
+            as ``"UIAutomationCore.dll"``.
+        required_attr: Optional name of an attribute the generated module
+            must expose. A partially generated cache that imports but lacks
+            the attribute is treated as corrupted and regenerated as well.
+
+    Returns:
+        The generated ``comtypes.gen`` friendly module for ``tlib``.
+
+    Raises:
+        ImportError: If the cache is corrupted and regeneration failed.
+        AttributeError: If ``required_attr`` is still missing after
+            regeneration.
+        TimeoutError: If the cross-process cache lock could not be acquired.
     """
     with comtypes_cache_lock():
         for attempt in (0, 1):
@@ -95,3 +143,4 @@ def safe_get_module(tlib, required_attr=None):
                 if attempt:
                     raise
                 _clear_gen_cache()
+    raise AssertionError("unreachable")  # pragma: no cover

--- a/src/windows_mcp/uia/comtypes_cache.py
+++ b/src/windows_mcp/uia/comtypes_cache.py
@@ -1,0 +1,97 @@
+"""Serialized, self-healing access to the comtypes generated-module cache.
+
+comtypes generates Python wrappers for COM type libraries on first use and
+stores them in ``comtypes/gen``. When two processes generate that cache
+concurrently (e.g. an MCP host spawning multiple server instances, see
+issue #357), or generation is interrupted, the cache is left corrupted and
+every subsequent startup fails with ImportError/AttributeError.
+
+``safe_get_module`` wraps ``comtypes.client.GetModule`` with
+
+1. a cross-process file lock so only one process generates at a time, and
+2. automatic cache clearing + regeneration when corruption is detected.
+"""
+
+import hashlib
+import msvcrt
+import os
+import shutil
+import sys
+import tempfile
+from contextlib import contextmanager
+
+import comtypes.client
+
+_LOCK_PATH = os.path.join(
+    tempfile.gettempdir(),
+    "comtypes-gen-%s.lock" % hashlib.md5(sys.prefix.encode("utf-8")).hexdigest(),
+)
+
+
+@contextmanager
+def comtypes_cache_lock():
+    """Cross-process lock serializing comtypes.gen cache generation."""
+    fd = os.open(_LOCK_PATH, os.O_CREAT | os.O_RDWR)
+    try:
+        while True:
+            try:
+                # Blocks and retries for ~10s, then raises OSError; loop
+                # until the other process releases the lock.
+                msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+                break
+            except OSError:
+                continue
+        yield
+    finally:
+        try:
+            msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+        except OSError:
+            pass
+        os.close(fd)
+
+
+def _clear_gen_cache() -> None:
+    """Delete generated modules so comtypes can regenerate them cleanly."""
+    try:
+        import comtypes.gen as gen
+
+        gen_dir = os.path.dirname(gen.__file__)
+    except Exception:
+        return
+    for name in os.listdir(gen_dir):
+        if name == "__init__.py":
+            continue
+        path = os.path.join(gen_dir, name)
+        try:
+            if os.path.isdir(path):
+                shutil.rmtree(path, ignore_errors=True)
+            else:
+                os.remove(path)
+        except OSError:
+            pass
+    for mod_name in list(sys.modules):
+        if mod_name.startswith("comtypes.gen."):
+            del sys.modules[mod_name]
+
+
+def safe_get_module(tlib, required_attr=None):
+    """``comtypes.client.GetModule`` with locking and corrupt-cache recovery.
+
+    ``required_attr`` optionally names an attribute the generated module must
+    expose; a partially generated cache that imports but lacks it is treated
+    as corrupted and regenerated as well.
+    """
+    with comtypes_cache_lock():
+        for attempt in (0, 1):
+            try:
+                module = comtypes.client.GetModule(tlib)
+                if required_attr is not None and not hasattr(module, required_attr):
+                    raise AttributeError(
+                        "generated module %r lacks %r (corrupted cache)"
+                        % (getattr(module, "__name__", tlib), required_attr)
+                    )
+                return module
+            except (ImportError, AttributeError):
+                if attempt:
+                    raise
+                _clear_gen_cache()

--- a/src/windows_mcp/uia/core.py
+++ b/src/windows_mcp/uia/core.py
@@ -46,6 +46,7 @@ TreeNode = Any
 from .enums import *  # noqa: E402
 from .enums import _INPUTUnion  # noqa: E402
 from .exceptions import from_com_error  # noqa: E402
+from .comtypes_cache import safe_get_module  # noqa: E402
 
 
 class _AutomationClient:
@@ -66,7 +67,9 @@ class _AutomationClient:
         tryCount = 3
         for retry in range(tryCount):
             try:
-                self.UIAutomationCore = comtypes.client.GetModule("UIAutomationCore.dll")
+                self.UIAutomationCore = safe_get_module(
+                    "UIAutomationCore.dll", required_attr="IUIAutomation"
+                )
                 self.IUIAutomation = comtypes.client.CreateObject(
                     "{ff48dba4-60ef-4201-aa87-54103eef594e}",
                     interface=self.UIAutomationCore.IUIAutomation,


### PR DESCRIPTION
Fixes #357

## Problem
When the MCP host (e.g. Claude Desktop) spawns multiple server instances near-simultaneously, both processes generate the comtypes cache in `comtypes/gen` concurrently on first run. Concurrent writes leave the GUID module and the friendly wrapper (`UIAutomationClient.py`) mismatched or partial. Every subsequent startup then crashes with `ImportError`/`AttributeError` until the cache is manually deleted. Recurs after every venv rebuild.

## Fix
New module `windows_mcp/uia/comtypes_cache.py` providing `safe_get_module()`:

1. **Cross-process file lock** (msvcrt, lockfile in temp keyed by `sys.prefix`) so only one process generates the cache at a time.
2. **Corrupt-cache recovery**: on `ImportError`/`AttributeError` (or when the generated module lacks an expected attribute) the generated files are cleared, `sys.modules` entries purged, and generation retried once.

Used at both generation sites: `uia/core.py` (UIAutomationCore.dll) and `tree/ia2.py` (oleacc.dll). This also self-heals installs that already have a corrupted cache — no manual venv deletion needed.

## Testing
- Clean generation: OK
- Corrupted cache (truncated GUID module) -> automatic recovery: OK
- 4 concurrent processes generating on an empty cache (the original race): all OK