### PR TITLE
fix: stop writing to stdout, which carries the stdio JSON-RPC protocol

### DIFF
--- a/src/windows_mcp/infrastructure/analytics.py
+++ b/src/windows_mcp/infrastructure/analytics.py
@@ -115,8 +115,6 @@ class PostHogAnalytics:
 
         duration = result.get("duration_ms", 0)
         success_mark = "SUCCESS" if result.get("success") else "FAILED"
-        # Using print for immediate visibility in console during debugging
-        print(f"[Analytics] {tool_name}: {success_mark} ({duration}ms)")
         logger.info(f"{tool_name}: {success_mark} ({duration}ms)")
 
     async def track_error(self, error: Exception, context: Dict[str, Any]) -> None:

--- a/src/windows_mcp/tree/service.py
+++ b/src/windows_mcp/tree/service.py
@@ -568,7 +568,6 @@ class Tree:
                                         for word,boxes in words:
                                             for box in boxes:
                                                 word_elements.append((word,box))
-                                                print(word,box)
                                 except Exception:
                                     pass
 

--- a/tests/test_no_stdout_writes.py
+++ b/tests/test_no_stdout_writes.py
@@ -1,0 +1,105 @@
+"""Guard against bare `print()` in the server's source.
+
+The default transport is stdio (`__main__.py`), where stdout *is* the
+JSON-RPC channel -- as the codebase already notes elsewhere: "Written to
+stderr because stdout carries the stdio protocol". Anything printed to
+stdout is interleaved into that stream and corrupts the framing the client
+is parsing.
+
+This is a static scan rather than a runtime check, so it needs no Windows
+imports and runs anywhere.
+
+Two narrow exemptions, both deliberate:
+
+* prints lexically inside an `if ...debug...:` block -- opt-in, off by
+  default, and never reached in normal operation;
+* `RunByHotKey`, a standalone hotkey-runner utility carried over from the
+  upstream `uiautomation` library that the MCP server never invokes.
+
+Anything else should use `logger`, which is already configured to write to
+stderr.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+SRC_ROOT = Path(__file__).resolve().parent.parent / "src" / "windows_mcp"
+
+# Enclosing functions exempted wholesale. Keyed by name rather than line
+# number so the allowlist survives edits elsewhere in the file.
+EXEMPT_FUNCTIONS = {
+    "threadFunc",  # nested inside RunByHotKey; upstream uiautomation utility
+}
+
+
+def _is_debug_gated(ancestors: list[ast.AST]) -> bool:
+    """True if any enclosing `if` tests something named like a debug flag."""
+    for node in ancestors:
+        if isinstance(node, ast.If):
+            test_source = ast.dump(node.test).lower()
+            if "debug" in test_source:
+                return True
+    return False
+
+
+def _enclosing_function(ancestors: list[ast.AST]) -> str | None:
+    for node in reversed(ancestors):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return node.name
+    return None
+
+
+def _find_stdout_prints(path: Path) -> list[tuple[int, str | None]]:
+    """Return (lineno, enclosing function) for each non-exempt print call.
+
+    Only `ast.Call` nodes count, so prints appearing inside docstring
+    examples are excluded for free -- those are strings, not calls.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    offenders: list[tuple[int, str | None]] = []
+
+    def walk(node: ast.AST, ancestors: list[ast.AST]) -> None:
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "print"
+        ):
+            # `print(..., file=sys.stderr)` is not a stdout write.
+            writes_elsewhere = any(kw.arg == "file" for kw in node.keywords)
+            function = _enclosing_function(ancestors)
+            if (
+                not writes_elsewhere
+                and not _is_debug_gated(ancestors)
+                and function not in EXEMPT_FUNCTIONS
+            ):
+                offenders.append((node.lineno, function))
+
+        for child in ast.iter_child_nodes(node):
+            walk(child, ancestors + [node])
+
+    walk(tree, [])
+    return offenders
+
+
+def _source_files() -> list[Path]:
+    return sorted(SRC_ROOT.rglob("*.py"))
+
+
+class TestNoStdoutWrites:
+    def test_source_tree_was_found(self):
+        """Fail loudly rather than passing vacuously on a bad path."""
+        assert _source_files(), f"no Python sources under {SRC_ROOT}"
+
+    @pytest.mark.parametrize(
+        "path", _source_files(), ids=lambda p: str(p.relative_to(SRC_ROOT))
+    )
+    def test_no_bare_print(self, path: Path):
+        offenders = _find_stdout_prints(path)
+        assert offenders == [], "\n".join(
+            f"{path.relative_to(SRC_ROOT)}:{line} in {func or '<module>'} "
+            "writes to stdout, which carries the stdio JSON-RPC protocol; "
+            "use logger instead"
+            for line, func in offenders
+        )


### PR DESCRIPTION
The default transport is stdio, where **stdout is the JSON-RPC channel**. `__main__.py:189` already says as much — *"Written to stderr because stdout carries the stdio protocol"* — but two live code paths write to it anyway, interleaving plain text into the framing the client is parsing.

## `tree/service.py`

```python
for box in boxes:
    word_elements.append((word, box))
    print(word, box)              # <- removed
```

This runs inside `tree_traversal`, for every `EditControl` / `DocumentControl` / `ImageControl` encountered, once per word. A single text field can emit dozens of lines into the protocol stream; a document control can emit hundreds.

It looks like leftover debugging from the word-bounding-box work — the value is already accumulated on the line above, and the print does nothing else. The enclosing `try/except Exception: pass` doesn't help, since the write has already happened by the time anything could raise.

## `infrastructure/analytics.py`

```python
# Using print for immediate visibility in console during debugging
print(f"[Analytics] {tool_name}: {success_mark} ({duration}ms)")
logger.info(f"{tool_name}: {success_mark} ({duration}ms)")   # same text, already
```

The line immediately below sends the identical message to the logger, which writes to stderr. Removing the print loses nothing.

## Regression guard

`tests/test_no_stdout_writes.py` statically scans the source tree with `ast`. Design notes:

- counts only `ast.Call` nodes, so prints inside **docstring examples** (`controls.py:486`, `patterns.py:1587`, and others) are excluded for free — they're strings, not calls;
- ignores `print(..., file=...)`, which isn't a stdout write;
- no Windows imports, so it runs anywhere.

Two narrow exemptions are encoded rather than blanket-skipping any file:

| exemption | why |
|---|---|
| prints lexically inside an `if ...debug...:` block | opt-in, off by default, never hit in normal operation |
| `threadFunc` inside `RunByHotKey` | upstream `uiautomation` hotkey utility the server never invokes |

Together those cover the three remaining prints in `uia/controls.py` (5421, 5442, 5912). I verified the exemptions aren't over-broad by injecting an ungated `print` into `GetWordBoundingBoxAtPoint` in that same file — still caught. Reintroducing the exact removed line at `service.py:571` is also caught.

## Testing caveat

**I could not run the suite locally.** `pywin32` has no macOS wheels, so `uv sync` fails outright on this machine. Verification was:

- static AST analysis of all 65 source files → 0 offenders after the fix;
- direct execution of the scanner's functions, including mutation checks in both directions (regression caught, exemptions narrow, `file=sys.stderr` correctly ignored).

CI runs on `windows-latest` and will exercise the real suite. Worth a reviewer with a Windows box confirming the protocol noise is actually gone from a snapshot on an editable control — that's the observable symptom I couldn't reproduce from here.
