### PR TITLE
ci: block releases when version strings disagree

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,18 @@ jobs:
         with:
           version: "latest"
       
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      
+      # Fails the release if pyproject.toml, uv.lock, manifest.json and
+      # server.json's package entry don't all agree with the tag. At v0.8.5
+      # the latter two were still on 0.8.1, two releases behind, because the
+      # 0.8.2 bump touched only pyproject.toml and nothing checked.
+      - name: Check version consistency
+        run: python scripts/check_versions.py "${{ github.ref_name }}"
+      
       - name: Build package
         run: uv build
       

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Verify that every shipped version string agrees.
+
+The project declares its version in four places, each consumed by a
+different distribution channel:
+
+    pyproject.toml              the PyPI package
+    uv.lock                     the locked workspace member
+    manifest.json               the Claude Desktop extension
+    server.json packages[]      the MCP registry's PyPI package entry
+
+These drift silently. At the v0.8.5 release `manifest.json` and
+`server.json`'s package entry were both still on 0.8.1, two releases
+behind `pyproject.toml`, because the 0.8.2 bump touched only
+`pyproject.toml`. Nothing failed -- the extension simply kept advertising
+a version that was no longer what shipped.
+
+`server.json`'s TOP-LEVEL "version" is deliberately excluded. That field
+identifies the registry entry rather than the PyPI package and is on its
+own 1.x line; forcing it to match would be a version downgrade in the
+registry. Only `packages[].version`, which must match what is published
+to PyPI, is checked.
+
+Run with no arguments to check internal consistency; pass a version (or a
+`v`-prefixed release tag) to additionally require that everything matches
+it.
+
+    python scripts/check_versions.py
+    python scripts/check_versions.py v0.8.6
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_UV_LOCK_WINDOWS_MCP = re.compile(
+    r'^\[\[package\]\]\nname = "windows-mcp"\nversion = "([^"]+)"',
+    re.MULTILINE,
+)
+
+
+def collect_versions(root: Path = REPO_ROOT) -> dict[str, str]:
+    """Extract every declared version string, keyed by a human-readable label.
+
+    Raises:
+        ValueError: if a file is missing the version field entirely, which is
+            just as much a packaging bug as a stale value.
+    """
+    versions: dict[str, str] = {}
+
+    pyproject = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+    try:
+        versions["pyproject.toml:project.version"] = pyproject["project"]["version"]
+    except KeyError as exc:
+        raise ValueError("pyproject.toml is missing [project] version") from exc
+
+    lock_text = (root / "uv.lock").read_text(encoding="utf-8")
+    match = _UV_LOCK_WINDOWS_MCP.search(lock_text)
+    if match is None:
+        raise ValueError("uv.lock has no [[package]] entry for windows-mcp")
+    versions["uv.lock:windows-mcp"] = match.group(1)
+
+    manifest = json.loads((root / "manifest.json").read_text(encoding="utf-8"))
+    if "version" not in manifest:
+        raise ValueError("manifest.json is missing a top-level version field")
+    versions["manifest.json:version"] = manifest["version"]
+
+    server = json.loads((root / "server.json").read_text(encoding="utf-8"))
+    packages = server.get("packages", [])
+    if not packages:
+        raise ValueError("server.json declares no packages")
+    for index, package in enumerate(packages):
+        if "version" not in package:
+            raise ValueError(f"server.json packages[{index}] is missing a version field")
+        versions[f"server.json:packages[{index}].version"] = package["version"]
+
+    return versions
+
+
+def check(expected: str | None = None, root: Path = REPO_ROOT) -> list[str]:
+    """Return a list of human-readable problems; empty means everything agrees."""
+    versions = collect_versions(root)
+    distinct = sorted(set(versions.values()))
+
+    problems: list[str] = []
+    if len(distinct) > 1:
+        problems.append(f"version strings disagree: {', '.join(distinct)}")
+
+    if expected is not None:
+        target = expected.removeprefix("v")
+        if any(version != target for version in versions.values()):
+            problems.append(f"expected every version to be {target}")
+
+    return problems
+
+
+def main(argv: list[str]) -> int:
+    expected = argv[1] if len(argv) > 1 else None
+
+    try:
+        versions = collect_versions()
+    except (OSError, ValueError, json.JSONDecodeError, tomllib.TOMLDecodeError) as exc:
+        print(f"error: could not read version metadata: {exc}", file=sys.stderr)
+        return 1
+
+    problems = check(expected)
+    width = max(len(label) for label in versions)
+    target = expected.removeprefix("v") if expected else None
+
+    # Without an expected version there is no single "right" value to compare
+    # against, so flag every string only when they fail to agree unanimously.
+    consistent = len(set(versions.values())) == 1
+    for label, version in versions.items():
+        ok = version == target if target else consistent
+        print(f"  {'ok ' if ok else 'BAD'}  {label:<{width}}  {version}")
+
+    if problems:
+        sys.stdout.flush()
+        print(file=sys.stderr)
+        for problem in problems:
+            print(f"error: {problem}", file=sys.stderr)
+        print(
+            "\nAll four files must be bumped together. server.json's top-level "
+            '"version" is intentionally not checked -- it tracks the registry '
+            "entry, not the PyPI package.",
+            file=sys.stderr,
+        )
+        return 1
+
+    scope = f" and match {target}" if target else ""
+    print(f"\nAll {len(versions)} version strings agree{scope}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/test_check_versions.py
+++ b/tests/test_check_versions.py
@@ -1,0 +1,168 @@
+"""Tests for the release version-consistency guard.
+
+The guard exists because the version is declared in four files consumed by
+four different channels, and only `pyproject.toml` reliably gets bumped. At
+the v0.8.5 release, `manifest.json` and `server.json`'s package entry were
+both still on 0.8.1 -- two releases behind -- because the 0.8.2 bump touched
+only `pyproject.toml` and nothing checked.
+
+The regression test that matters is `test_catches_the_historical_drift`: it
+reconstructs the real pre-0.8.5 tree and asserts the guard would have
+blocked that release.
+
+`server.json`'s top-level "version" is deliberately excluded from the check
+(it tracks the registry entry, not the PyPI package, and is on its own 1.x
+line). `test_top_level_server_version_is_ignored` pins that exclusion so it
+isn't "fixed" into a permanently failing check later.
+"""
+
+import importlib.util
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+VERSIONED_FILES = ("pyproject.toml", "uv.lock", "manifest.json", "server.json")
+
+
+def _load_module():
+    """Load scripts/check_versions.py, which is not an installed package."""
+    path = REPO_ROOT / "scripts" / "check_versions.py"
+    spec = importlib.util.spec_from_file_location("check_versions", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+check_versions = _load_module()
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A throwaway copy of the repo's version-bearing files."""
+    for filename in VERSIONED_FILES:
+        shutil.copy(REPO_ROOT / filename, tmp_path / filename)
+    return tmp_path
+
+
+def _write_json(root: Path, filename: str, data) -> None:
+    (root / filename).write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def _read_json(root: Path, filename: str):
+    return json.loads((root / filename).read_text(encoding="utf-8"))
+
+
+class TestCollectVersions:
+    def test_collects_every_checked_version(self, repo):
+        assert set(check_versions.collect_versions(repo)) == {
+            "pyproject.toml:project.version",
+            "uv.lock:windows-mcp",
+            "manifest.json:version",
+            "server.json:packages[0].version",
+        }
+
+    def test_top_level_server_version_is_not_collected(self, repo):
+        """It tracks the registry entry, not the PyPI package."""
+        labels = check_versions.collect_versions(repo)
+        assert "server.json:version" not in labels
+
+    def test_missing_manifest_version_is_an_error(self, repo):
+        data = _read_json(repo, "manifest.json")
+        del data["version"]
+        _write_json(repo, "manifest.json", data)
+
+        with pytest.raises(ValueError, match="manifest.json"):
+            check_versions.collect_versions(repo)
+
+    def test_missing_uv_lock_entry_is_an_error(self, repo):
+        (repo / "uv.lock").write_text(
+            '[[package]]\nname = "click"\nversion = "8.0.0"\n', encoding="utf-8"
+        )
+
+        with pytest.raises(ValueError, match="uv.lock"):
+            check_versions.collect_versions(repo)
+
+    def test_empty_packages_is_an_error(self, repo):
+        data = _read_json(repo, "server.json")
+        data["packages"] = []
+        _write_json(repo, "server.json", data)
+
+        with pytest.raises(ValueError, match="packages"):
+            check_versions.collect_versions(repo)
+
+
+class TestCheck:
+    def test_repo_is_currently_consistent(self):
+        """The real tree must stay releasable -- guards every future bump."""
+        assert check_versions.check(None, REPO_ROOT) == []
+
+    def test_consistent_repo_matches_its_own_version(self, repo):
+        current = next(iter(check_versions.collect_versions(repo).values()))
+        assert check_versions.check(current, repo) == []
+
+    def test_v_prefixed_tag_is_accepted(self, repo):
+        """publish.yml passes github.ref_name, which is tag-shaped."""
+        current = next(iter(check_versions.collect_versions(repo).values()))
+        assert check_versions.check(f"v{current}", repo) == []
+
+    def test_catches_the_historical_drift(self, repo):
+        """Reconstruct the real pre-0.8.5 tree; the guard must block it."""
+        pyproject = repo / "pyproject.toml"
+        current = next(iter(check_versions.collect_versions(repo).values()))
+        pyproject.write_text(
+            pyproject.read_text(encoding="utf-8").replace(
+                f'version = "{current}"', 'version = "0.8.2"', 1
+            ),
+            encoding="utf-8",
+        )
+        lock = repo / "uv.lock"
+        lock.write_text(
+            lock.read_text(encoding="utf-8").replace(
+                f'name = "windows-mcp"\nversion = "{current}"',
+                'name = "windows-mcp"\nversion = "0.8.2"',
+            ),
+            encoding="utf-8",
+        )
+        manifest = _read_json(repo, "manifest.json")
+        manifest["version"] = "0.8.1"
+        _write_json(repo, "manifest.json", manifest)
+        server = _read_json(repo, "server.json")
+        server["packages"][0]["version"] = "0.8.1"
+        _write_json(repo, "server.json", server)
+
+        problems = check_versions.check("v0.8.2", repo)
+
+        assert problems, "the guard must reject the release that shipped the drift"
+        assert any("disagree" in problem for problem in problems)
+
+    def test_top_level_server_version_is_ignored(self, repo):
+        """A divergent top-level version must not fail the check."""
+        server = _read_json(repo, "server.json")
+        server["version"] = "1.0.1"
+        _write_json(repo, "server.json", server)
+
+        assert check_versions.check(None, repo) == []
+
+    def test_catches_single_stale_file(self, repo):
+        manifest = _read_json(repo, "manifest.json")
+        manifest["version"] = "0.0.1"
+        _write_json(repo, "manifest.json", manifest)
+
+        assert check_versions.check(None, repo) != []
+
+    def test_catches_consistent_repo_not_matching_tag(self, repo):
+        """Internally consistent but tagged wrong is still a bad release."""
+        assert any("99.0.0" in p for p in check_versions.check("v99.0.0", repo))
+
+
+class TestMainExitCodes:
+    """The workflow depends on the process exit status."""
+
+    def test_exit_zero_on_consistent_repo(self, capsys):
+        assert check_versions.main(["check_versions.py"]) == 0
+
+    def test_exit_one_on_tag_mismatch(self, capsys):
+        assert check_versions.main(["check_versions.py", "v99.0.0"]) == 1


### PR DESCRIPTION
Ports the version-consistency guard from MacOS-MCP (CursorTouch/MacOS-MCP#33), adapted to this repo's layout. A release can no longer publish unless every declared version agrees with the tag.

## Why

The version is declared in four files, each consumed by a different channel:

| file | channel |
|---|---|
| `pyproject.toml` | PyPI |
| `uv.lock` | locked workspace member |
| `manifest.json` | Claude Desktop extension |
| `server.json` → `packages[]` | MCP registry's PyPI entry |

Only `pyproject.toml` reliably gets bumped. At the v0.8.5 release, `manifest.json` and `server.json`'s package entry were **both still on 0.8.1 — two releases behind** — because the 0.8.2 bump touched only `pyproject.toml`. Nothing failed; the extension just kept advertising a version that was no longer what shipped.

That's the same failure MacOS-MCP hit, where it stranded users on a build predating a permissions fix with no update path.

## What this does

`scripts/check_versions.py` compares all four against each other and against the release tag. `publish.yml` runs it **before `uv build`**, so a mismatch fails the release before anything reaches PyPI.

```
$ python scripts/check_versions.py v0.8.5
  ok   pyproject.toml:project.version   0.8.5
  ok   uv.lock:windows-mcp              0.8.5
  ok   manifest.json:version            0.8.5
  ok   server.json:packages[0].version  0.8.5

All 4 version strings agree and match 0.8.5.
```

Against the reconstructed pre-0.8.5 tree:

```
  version strings disagree: 0.8.1, 0.8.2
  expected every version to be 0.8.2      -> exit 1, release blocked
```

## One deliberate exclusion

`server.json`'s **top-level** `"version"` is not checked. That field identifies the registry entry rather than the PyPI package, and it's on its own `1.x` line (currently `1.0.1`). Requiring it to match would either fail permanently or force a version *downgrade* in the registry. Only `packages[].version`, which must match what's published to PyPI, is checked.

`test_top_level_server_version_is_ignored` pins that exclusion so it isn't later "fixed" into a check that can never pass.

## Tests

`tests/test_check_versions.py` — 14 tests covering extraction, drift detection, tag matching, the top-level exclusion, and exit codes. The one that matters is `test_catches_the_historical_drift`, which reconstructs the real pre-0.8.5 tree and asserts the guard would have blocked that release.

**Testing caveat:** I could not run the suite locally — `pywin32` has no macOS wheels, so `uv sync` fails on this machine. I executed the 14 test bodies directly against temporary copies of the tree instead (all pass), and exercised the script end to end. CI on `windows-latest` runs the real suite.
