### PR TITLE
docs: add PyPI downloads badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
   <img src="https://img.shields.io/badge/python-3.13%2B-blue" alt="Python">
   <img src="https://img.shields.io/badge/platform-Windows%207–11-blue" alt="Platform: Windows 7 to 11">
   <img src="https://img.shields.io/github/last-commit/CursorTouch/Windows-MCP" alt="Last Commit">
+  <a href="https://pepy.tech/projects/windows-mcp">
+    <img src="https://static.pepy.tech/personalized-badge/windows-mcp?period=total&amp;units=INTERNATIONAL_SYSTEM&amp;left_color=BLACK&amp;right_color=GREEN&amp;left_text=downloads" alt="PyPI Downloads">
+  </a>
   <br>
   <a href="https://x.com/CursorTouch">
     <img src="https://img.shields.io/badge/follow-%40CursorTouch-1DA1F2?logo=twitter&style=flat" alt="Follow on Twitter">


### PR DESCRIPTION
Adds the pepy.tech downloads badge (currently reading **194k**).

## Placement

First badge row, after `Last Commit` and before the `<br>` that separates project badges from the social ones:

```
license | python | platform | last-commit | downloads
---
twitter | discord
```

It is a project statistic, so it groups with `last-commit` rather than with the Twitter/Discord links.

## Formatting

Written as `<a><img>` rather than markdown, because the surrounding `<div align="center">` is raw HTML and every other badge in that block uses the same form — markdown image syntax is unreliable inside an HTML block without surrounding blank lines.

The query string uses `&amp;` for the same reason the trendshift badge directly below it does.

Verified the badge URL returns `200 image/svg+xml`.